### PR TITLE
Add missing LaTeX font packages to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   texlive-xetex \
   latexmk \
   pandoc \
-  texlive-fonts-recommended \
   lmodern \
   && update-ca-certificates \
   && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   texlive-xetex \
   latexmk \
   pandoc \
+  texlive-fonts-recommended \
+  lmodern \
   && update-ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- Adds missing LaTeX font packages to the Dockerfile to fix paper generation font issues

## Test plan
- [ ] Verify Docker image builds successfully
- [ ] Confirm LaTeX paper generation renders fonts correctly