### PR TITLE
refactor(x402): clarify naming conventions

### DIFF
--- a/client/src/pages/ChatPage.tsx
+++ b/client/src/pages/ChatPage.tsx
@@ -78,7 +78,7 @@ export function ChatPage({ sessionId: urlSessionId }: ChatPageProps) {
   };
 
   // Determine which user ID to use
-  // Priority: x402 wallet > JWT auth userId > localStorage fallback
+  // Priority: x402 payment > JWT auth userId > localStorage fallback
   const actualUserId = x402Enabled
     ? embeddedWalletAddress
       ? walletAddressToUUID(embeddedWalletAddress)

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import { filesRoute } from "./routes/files";
 import { x402Route } from "./routes/x402";
 import { x402ChatRoute } from "./routes/x402/chat";
 import { x402DeepResearchRoute } from "./routes/x402/deep-research";
-import { x402AgentsRoute } from "./routes/x402/agents";
+import { x402IndividualAgentsRoute } from "./routes/x402/agents";
 import { initializeX402Service } from "./middleware/x402/service";
 import { b402Route } from "./routes/b402";
 import { b402ChatRoute } from "./routes/b402/chat";
@@ -272,7 +272,7 @@ const app = new Elysia()
   .use(x402Route) // GET /api/x402/* for config, pricing, payments, health
   .use(x402ChatRoute) // POST /api/x402/chat for payment-gated chat
   .use(x402DeepResearchRoute) // POST /api/x402/deep-research/start, GET /api/x402/deep-research/status/:messageId
-  .use(x402AgentsRoute) // POST /api/x402/agents/* for individual agent access
+  .use(x402IndividualAgentsRoute) // POST /api/x402/agents/* for individual agent access
 
   // b402 payment routes - BNB Chain (USDT)
   .use(b402Route) // GET /api/b402/* for config, pricing, health

--- a/src/routes/deep-research/start.ts
+++ b/src/routes/deep-research/start.ts
@@ -116,7 +116,7 @@ export async function deepResearchStartHandler(ctx: any) {
   }
 
   // Get userId from auth context (set by authResolver middleware)
-  // Auth context handles: x402 wallet > JWT token > API key > body.userId > anonymous
+  // Auth context handles: x402 payment > JWT token > API key > body.userId > anonymous
   const auth = (request as any).auth as AuthContext | undefined;
   let userId = auth?.userId || generateUUID();
   const source = auth?.method === "x402" ? "x402" : "api";

--- a/src/routes/x402/agents.ts
+++ b/src/routes/x402/agents.ts
@@ -92,7 +92,7 @@ function getAgentPricing() {
     }));
 }
 
-export const x402AgentsRoute = new Elysia({ prefix: "/api/x402/agents" })
+export const x402IndividualAgentsRoute = new Elysia({ prefix: "/api/x402/agents" })
   // List all available agents and their pricing
   .get("/", () => {
     return {


### PR DESCRIPTION
## Summary
- Renamed `x402AgentsRoute` → `x402IndividualAgentsRoute` to distinguish from the orchestrator route
- Updated "x402 wallet" comments to "x402 payment" in auth priority documentation (the "wallet" label was confusing since all x402 routes use wallets)

## What changed
| File | Change |
|---|---|
| `src/routes/x402/agents.ts` | Export renamed |
| `src/index.ts` | Import + `.use()` updated |
| `src/routes/deep-research/start.ts` | Comment: "x402 wallet" → "x402 payment" |
| `client/src/pages/ChatPage.tsx` | Comment: "x402 wallet" → "x402 payment" |

No URL paths, runtime behavior, or API contracts changed.

## Test plan
- [ ] Verify server starts without import errors
- [ ] Verify `/api/x402/agents/` listing endpoint still works
- [ ] Verify individual agent endpoints unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)