### PR TITLE
fix(x402): add signed poll tokens for deep research status endpoint

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./src/test-setup.ts"]

--- a/scripts/x402/request-faucet.ts
+++ b/scripts/x402/request-faucet.ts
@@ -16,7 +16,8 @@ if (!PRIVATE_KEY) {
   process.exit(1);
 }
 
-const account = privateKeyToAccount(PRIVATE_KEY as `0x${string}`);
+const pk = PRIVATE_KEY.startsWith("0x") ? PRIVATE_KEY : `0x${PRIVATE_KEY}`;
+const account = privateKeyToAccount(pk as `0x${string}`);
 const TEST_WALLET = account.address;
 
 async function requestFaucet() {

--- a/scripts/x402/test-x402-agents.ts
+++ b/scripts/x402/test-x402-agents.ts
@@ -40,14 +40,22 @@ const ANALYSIS_TIMEOUT_MS = 300_000; // 5 min for analysis agent (calls external
 
 // ── Test Payloads ──────────────────────────────────────────────────────────
 
-// Small CSV for analysis agent
+// Gene expression dataset for analysis agent (RNA-seq TPM values)
+// 10 genes × 6 samples (3 tumor + 3 normal), biologically plausible values.
+// Oncogenes (MYC, EGFR, KRAS) are upregulated in tumor; tumor suppressors
+// (TP53, BRCA1, PTEN) are downregulated; GAPDH/ACTB/B2M stable as controls.
 const SAMPLE_CSV = [
-  "gene,expression_level,sample_type",
-  "TP53,8.2,tumor",
-  "BRCA1,3.1,tumor",
-  "MYC,12.5,tumor",
-  "TP53,4.1,normal",
-  "BRCA1,5.8,normal",
+  "gene,tumor_1,tumor_2,tumor_3,normal_1,normal_2,normal_3",
+  "TP53,12.4,14.1,11.8,45.6,42.3,48.1",
+  "BRCA1,8.7,10.2,7.5,38.3,35.7,41.2",
+  "PTEN,9.8,11.5,8.9,41.7,39.2,44.5",
+  "MYC,85.3,78.9,91.2,22.7,25.4,20.1",
+  "EGFR,72.1,68.4,75.8,18.9,21.3,16.5",
+  "KRAS,48.2,52.1,44.8,15.3,17.1,13.8",
+  "CDK4,67.4,62.8,71.3,25.1,27.8,23.4",
+  "GAPDH,150.2,148.7,151.8,148.7,150.3,147.2",
+  "ACTB,180.5,177.3,182.1,177.3,179.8,175.9",
+  "B2M,95.4,93.8,96.7,93.8,95.1,92.5",
 ].join("\n");
 
 const SAMPLE_CSV_BASE64 = Buffer.from(SAMPLE_CSV).toString("base64");
@@ -147,13 +155,13 @@ const AGENT_TESTS: AgentTest[] = [
     price: "$0.025",
     input: {
       objective:
-        "Analyze gene expression patterns in tumor vs normal samples to identify differentially expressed genes",
+        "Analyze the gene expression data in the attached CSV file. Compare tumor vs normal samples and identify which genes are differentially expressed. Calculate fold changes and statistical significance.",
       datasets: [
         {
-          filename: "test_gene_expression.csv",
+          filename: "gene_expression.csv",
           id: "test-dataset-1",
           description:
-            "Gene expression levels for TP53, BRCA1, and MYC in tumor and normal tissue samples",
+            "RNA-seq normalized expression data (TPM) for 10 cancer-related genes across 6 samples (3 tumor, 3 normal). Includes oncogenes (MYC, EGFR, KRAS), tumor suppressors (TP53, BRCA1, PTEN), and housekeeping controls (GAPDH, ACTB, B2M).",
           content: SAMPLE_CSV_BASE64,
         },
       ],

--- a/scripts/x402/test-x402-agents.ts
+++ b/scripts/x402/test-x402-agents.ts
@@ -1,0 +1,445 @@
+/**
+ * x402 Individual Agent Integration Tests
+ *
+ * Tests all 7 x402 agent endpoints with REAL testnet payments on Base Sepolia.
+ * Stores full inputs/outputs in test-results.json for review.
+ *
+ * Required env:
+ *   X402_TEST_PRIVATE_KEY  — test wallet private key with Base Sepolia USDC
+ *
+ * Usage:
+ *   bun run scripts/x402/test-x402-agents.ts
+ *
+ * Total cost: ~$0.10 USDC (testnet) per run
+ */
+
+import { wrapFetchWithPayment, x402Client } from "@x402/fetch";
+import { registerExactEvmScheme } from "@x402/evm/exact/client";
+import { privateKeyToAccount } from "viem/accounts";
+import { spawn, type Subprocess } from "bun";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+// ── Configuration ──────────────────────────────────────────────────────────
+
+const PRIVATE_KEY = process.env.X402_TEST_PRIVATE_KEY;
+if (!PRIVATE_KEY) {
+  console.error("❌ X402_TEST_PRIVATE_KEY not set in environment");
+  process.exit(1);
+}
+
+const SERVER_PORT = Number(process.env.PORT) || 8080;
+const BASE_URL = `http://localhost:${SERVER_PORT}`;
+// Register both CAIP-2 and common name formats to match whatever the server uses
+const NETWORK = process.env.X402_NETWORK || "eip155:84532";
+const NETWORK_CAIP2 = "eip155:84532"; // Base Sepolia CAIP-2 standard
+const HEALTH_TIMEOUT_MS = 60_000;
+const HEALTH_POLL_INTERVAL_MS = 2_000;
+const REQUEST_TIMEOUT_MS = 180_000; // 3 min per agent (LLM + external services can be slow)
+const ANALYSIS_TIMEOUT_MS = 300_000; // 5 min for analysis agent (calls external service)
+
+// ── Test Payloads ──────────────────────────────────────────────────────────
+
+// Small CSV for analysis agent
+const SAMPLE_CSV = [
+  "gene,expression_level,sample_type",
+  "TP53,8.2,tumor",
+  "BRCA1,3.1,tumor",
+  "MYC,12.5,tumor",
+  "TP53,4.1,normal",
+  "BRCA1,5.8,normal",
+].join("\n");
+
+const SAMPLE_CSV_BASE64 = Buffer.from(SAMPLE_CSV).toString("base64");
+
+interface AgentTest {
+  agent: string;
+  endpoint: string;
+  price: string;
+  input: Record<string, unknown>;
+}
+
+const AGENT_TESTS: AgentTest[] = [
+  {
+    agent: "literature",
+    endpoint: "/api/x402/agents/literature",
+    price: "$0.01",
+    input: {
+      objective:
+        "CRISPR-Cas9 gene editing mechanisms in cancer therapy",
+      type: "OPENSCHOLAR",
+    },
+  },
+  {
+    agent: "reply",
+    endpoint: "/api/x402/agents/reply",
+    price: "$0.01",
+    input: {
+      message: "Explain the role of p53 in cancer suppression",
+      context: [],
+    },
+  },
+  {
+    agent: "planning",
+    endpoint: "/api/x402/agents/planning",
+    price: "$0.01",
+    input: {
+      objective:
+        "Investigate the therapeutic potential of mRNA vaccines for solid tumors",
+    },
+  },
+  {
+    agent: "hypothesis",
+    endpoint: "/api/x402/agents/hypothesis",
+    price: "$0.02",
+    input: {
+      objective: "mRNA vaccine efficacy in solid tumors",
+      completedTasks: [
+        {
+          id: "lit-1",
+          type: "LITERATURE",
+          objective: "mRNA vaccine tumor targeting",
+          output:
+            "Recent studies show mRNA vaccines can encode tumor-specific antigens, eliciting CD8+ T-cell responses. Phase I trials demonstrate safety and partial response in melanoma patients.",
+        },
+      ],
+    },
+  },
+  {
+    agent: "reflection",
+    endpoint: "/api/x402/agents/reflection",
+    price: "$0.015",
+    input: {
+      objective: "mRNA vaccines for solid tumors",
+      hypothesis:
+        "mRNA vaccines encoding personalized neoantigens may improve T-cell response in solid tumors",
+      completedTasks: [
+        {
+          type: "LITERATURE",
+          objective: "mRNA tumor vaccines clinical outcomes",
+          output:
+            "Phase II trials show 30% overall response rate in NSCLC patients treated with personalized mRNA neoantigen vaccines. Combination with anti-PD1 improved response to 48%.",
+        },
+      ],
+    },
+  },
+  {
+    agent: "discovery",
+    endpoint: "/api/x402/agents/discovery",
+    price: "$0.02",
+    input: {
+      completedTasks: [
+        {
+          id: "lit-1",
+          type: "LITERATURE",
+          objective: "mRNA vaccine delivery mechanisms",
+          output:
+            "Key finding: lipid nanoparticle (LNP) delivery improves antigen presentation by 4x compared to naked mRNA. ionizable lipids with pKa 6.2-6.5 show optimal endosomal escape. Combination of DOTAP and cholesterol in 50:38.5 molar ratio yields highest transfection efficiency in dendritic cells.",
+        },
+      ],
+      hypothesis:
+        "LNP-encapsulated mRNA vaccines show superior immune activation due to enhanced dendritic cell uptake and antigen presentation",
+    },
+  },
+  {
+    agent: "analysis",
+    endpoint: "/api/x402/agents/analysis",
+    price: "$0.025",
+    input: {
+      objective:
+        "Analyze gene expression patterns in tumor vs normal samples to identify differentially expressed genes",
+      datasets: [
+        {
+          filename: "test_gene_expression.csv",
+          id: "test-dataset-1",
+          description:
+            "Gene expression levels for TP53, BRCA1, and MYC in tumor and normal tissue samples",
+          content: SAMPLE_CSV_BASE64,
+        },
+      ],
+      type: "BIO",
+    },
+  },
+];
+
+// ── Server Management ──────────────────────────────────────────────────────
+
+let serverProcess: Subprocess | null = null;
+
+async function startServer(): Promise<void> {
+  console.log("🚀 Starting server...");
+
+  const projectRoot = join(import.meta.dir, "../..");
+
+  // Resolve bun binary — may not be in default PATH
+  const bunBin =
+    typeof Bun !== "undefined" && Bun.which("bun")
+      ? Bun.which("bun")!
+      : join(
+          process.env.HOME || process.env.USERPROFILE || "~",
+          ".bun",
+          "bin",
+          "bun",
+        );
+
+  // Filter out empty-string env vars so Bun's built-in .env loading can
+  // provide the correct values (shell env with empty values takes precedence
+  // over .env file values, causing "API_KEY is not configured" errors)
+  const cleanEnv: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && value !== "") {
+      cleanEnv[key] = value;
+    }
+  }
+
+  serverProcess = spawn({
+    cmd: [bunBin, "src/index.ts"],
+    cwd: projectRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: cleanEnv,
+  });
+
+  // Wait for health check
+  const startTime = Date.now();
+  while (Date.now() - startTime < HEALTH_TIMEOUT_MS) {
+    try {
+      const res = await fetch(`${BASE_URL}/api/health`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      if (res.ok) {
+        console.log(`✅ Server ready (took ${Date.now() - startTime}ms)\n`);
+        return;
+      }
+    } catch {
+      // Server not ready yet
+    }
+    await Bun.sleep(HEALTH_POLL_INTERVAL_MS);
+  }
+
+  throw new Error(
+    `Server failed to start within ${HEALTH_TIMEOUT_MS / 1000}s`,
+  );
+}
+
+function stopServer(): void {
+  if (serverProcess) {
+    console.log("\n🛑 Stopping server...");
+    serverProcess.kill();
+    serverProcess = null;
+  }
+}
+
+// ── Payment Client Setup ───────────────────────────────────────────────────
+
+function createPaymentFetch() {
+  // Ensure private key has 0x prefix (viem requires it)
+  const pk = PRIVATE_KEY!.startsWith("0x") ? PRIVATE_KEY! : `0x${PRIVATE_KEY}`;
+  const account = privateKeyToAccount(pk as `0x${string}`);
+  console.log(`💳 Wallet: ${account.address}`);
+  console.log(`🌐 Network: ${NETWORK}\n`);
+
+  const client = new x402Client();
+  registerExactEvmScheme(client, {
+    signer: account,
+    networks: [NETWORK_CAIP2],
+  });
+
+  return {
+    x402Fetch: wrapFetchWithPayment(fetch, client),
+    walletAddress: account.address,
+  };
+}
+
+// ── Test Runner ────────────────────────────────────────────────────────────
+
+interface TestResult {
+  agent: string;
+  endpoint: string;
+  price: string;
+  input: Record<string, unknown>;
+  response: {
+    status: number;
+    body: unknown;
+    paymentHeader: unknown | null;
+  } | null;
+  durationMs: number;
+  success: boolean;
+  error: string | null;
+}
+
+async function runAgentTest(
+  test: AgentTest,
+  x402Fetch: typeof fetch,
+): Promise<TestResult> {
+  const startTime = Date.now();
+  const url = `${BASE_URL}${test.endpoint}`;
+
+  try {
+    const controller = new AbortController();
+    const agentTimeout = test.agent === "analysis" ? ANALYSIS_TIMEOUT_MS : REQUEST_TIMEOUT_MS;
+    const timeout = setTimeout(
+      () => controller.abort(),
+      agentTimeout,
+    );
+
+    const response = await x402Fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(test.input),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    const durationMs = Date.now() - startTime;
+
+    // Parse response body
+    let body: unknown;
+    const text = await response.text();
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = { rawText: text.slice(0, 2000) };
+    }
+
+    // Decode payment response header
+    let paymentHeader: unknown = null;
+    const paymentResponseHeader = response.headers.get("PAYMENT-RESPONSE");
+    if (paymentResponseHeader) {
+      try {
+        paymentHeader = JSON.parse(atob(paymentResponseHeader));
+      } catch {
+        paymentHeader = { raw: paymentResponseHeader.slice(0, 200) };
+      }
+    }
+
+    const success = response.status >= 200 && response.status < 300;
+
+    return {
+      agent: test.agent,
+      endpoint: test.endpoint,
+      price: test.price,
+      input: test.input,
+      response: {
+        status: response.status,
+        body,
+        paymentHeader,
+      },
+      durationMs,
+      success,
+      error: success ? null : `HTTP ${response.status}`,
+    };
+  } catch (err: any) {
+    const durationMs = Date.now() - startTime;
+    return {
+      agent: test.agent,
+      endpoint: test.endpoint,
+      price: test.price,
+      input: test.input,
+      response: null,
+      durationMs,
+      success: false,
+      error: err.message || String(err),
+    };
+  }
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("🧪 x402 Individual Agent Integration Tests\n");
+  console.log(`📋 Testing ${AGENT_TESTS.length} agents with real testnet payments\n`);
+
+  // Setup payment client
+  const { x402Fetch, walletAddress } = createPaymentFetch();
+
+  // Start server
+  await startServer();
+
+  const results: TestResult[] = [];
+  const overallStart = Date.now();
+
+  try {
+    // Run each agent test sequentially
+    for (let i = 0; i < AGENT_TESTS.length; i++) {
+      const test = AGENT_TESTS[i];
+      const label = `[${i + 1}/${AGENT_TESTS.length}]`;
+
+      process.stdout.write(
+        `${label} Testing ${test.agent} (${test.price})... `,
+      );
+
+      const result = await runAgentTest(test, x402Fetch);
+      results.push(result);
+
+      if (result.success) {
+        console.log(
+          `✅ ${result.durationMs}ms (HTTP ${result.response?.status})`,
+        );
+      } else {
+        console.log(
+          `❌ ${result.durationMs}ms — ${result.error}`,
+        );
+      }
+    }
+  } finally {
+    stopServer();
+  }
+
+  const totalDurationMs = Date.now() - overallStart;
+
+  // Build summary
+  const passed = results.filter((r) => r.success).length;
+  const failed = results.filter((r) => !r.success).length;
+  const prices = AGENT_TESTS.map((t) =>
+    parseFloat(t.price.replace("$", "")),
+  );
+  const totalCost = prices.reduce((sum, p) => sum + p, 0);
+
+  const output = {
+    timestamp: new Date().toISOString(),
+    wallet: walletAddress,
+    network: NETWORK,
+    serverUrl: BASE_URL,
+    results,
+    summary: {
+      total: results.length,
+      passed,
+      failed,
+      totalDurationMs,
+      totalCostUSD: `$${totalCost.toFixed(3)}`,
+    },
+  };
+
+  // Write results JSON
+  const outputPath = join(import.meta.dir, "test-results.json");
+  await writeFile(outputPath, JSON.stringify(output, null, 2));
+
+  // Print summary
+  console.log("\n" + "═".repeat(60));
+  console.log("📊 SUMMARY");
+  console.log("═".repeat(60));
+  console.log(`   Total:    ${results.length} agents`);
+  console.log(`   Passed:   ${passed} ✅`);
+  console.log(`   Failed:   ${failed} ❌`);
+  console.log(`   Duration: ${(totalDurationMs / 1000).toFixed(1)}s`);
+  console.log(`   Cost:     ${output.summary.totalCostUSD} (testnet USDC)`);
+  console.log(`   Results:  ${outputPath}`);
+  console.log("═".repeat(60));
+
+  if (failed > 0) {
+    console.log("\n❌ Failed agents:");
+    for (const r of results.filter((r) => !r.success)) {
+      console.log(`   - ${r.agent}: ${r.error}`);
+    }
+  }
+
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("💥 Fatal error:", err);
+  stopServer();
+  process.exit(1);
+});

--- a/src/routes/b402/deep-research.ts
+++ b/src/routes/b402/deep-research.ts
@@ -13,10 +13,20 @@ import { deepResearchStatusHandler } from "../deep-research/status";
  * - POST /start: Requires b402 payment
  * - GET /status: Free (no payment), but requires userId query param
  *   Handler validates ownership (message.user_id === userId)
+ *
+ * TODO: b402 deep research has been deprioritized but needs the following work:
+ * 1. The status endpoint is currently broken — it calls deepResearchStatusHandler
+ *    which requires request.auth from authResolver middleware, but no auth middleware
+ *    runs on this route (registered before b402Middleware). This means it always returns 401.
+ * 2. authResolver does not recognize b402Settlement (only x402Settlement), so even if
+ *    b402Middleware runs, the auth context won't be populated with b402 payer info.
+ * 3. Should adopt the same signed poll token mechanism as the x402 deep research route
+ *    (see src/routes/x402/deep-research.ts and src/services/pollToken.ts).
  */
 export const b402DeepResearchRoute = new Elysia()
-  // Status endpoint - NO payment required, but has ownership validation in handler
-  // Must be registered BEFORE b402Middleware to avoid payment requirement
+  // TODO: Status endpoint is broken — deepResearchStatusHandler requires auth context
+  // that is never set on this route. Needs poll token validation like x402 route.
+  // See src/routes/x402/deep-research.ts for the correct pattern.
   .get("/api/b402/deep-research/status/:messageId", deepResearchStatusHandler)
   // Payment-gated endpoints
   .use(b402Middleware())

--- a/src/routes/deep-research/statusUtils.ts
+++ b/src/routes/deep-research/statusUtils.ts
@@ -1,0 +1,152 @@
+/**
+ * Shared Deep Research Status Utilities
+ *
+ * Core status detection logic (processing/completed/failed) used by:
+ * - Standard status endpoint (with auth + ownership)
+ * - x402 status endpoint (with poll token)
+ *
+ * Does NOT perform any auth or ownership checks — callers are responsible.
+ */
+
+import { getMessage, getState } from "../../db/operations";
+
+export type DeepResearchStatusResponse = {
+  status: "processing" | "completed" | "failed";
+  messageId: string;
+  conversationId: string;
+  result?: {
+    text: string;
+    files?: Array<{
+      filename: string;
+      mimeType: string;
+      size?: number;
+    }>;
+    papers?: any[];
+    webSearchResults?: any[];
+  };
+  error?: string;
+  progress?: {
+    currentStep?: string;
+    completedSteps?: string[];
+  };
+};
+
+/**
+ * Fetch message and state, then determine deep research status.
+ *
+ * @param messageId - The message UUID to check
+ * @returns { response, httpStatus, message } where message is the DB record (for ownership checks)
+ */
+export async function getDeepResearchStatus(messageId: string): Promise<{
+  response: DeepResearchStatusResponse | { ok: false; error: string };
+  httpStatus: number;
+  message?: any;
+}> {
+  // Fetch the message
+  const message = await getMessage(messageId);
+  if (!message) {
+    return {
+      response: { ok: false, error: "Message not found" },
+      httpStatus: 404,
+    };
+  }
+
+  // Fetch the state
+  const stateId = message.state_id;
+  if (!stateId) {
+    return {
+      response: { ok: false, error: "Message has no associated state" },
+      httpStatus: 500,
+      message,
+    };
+  }
+
+  const state = await getState(stateId);
+  if (!state) {
+    return {
+      response: { ok: false, error: "State not found" },
+      httpStatus: 404,
+      message,
+    };
+  }
+
+  // Determine status based on state values
+  const stateValues = state.values || {};
+  const steps = stateValues.steps || {};
+
+  // Check if failed
+  if (stateValues.status === "failed" || stateValues.error) {
+    return {
+      response: {
+        status: "failed",
+        messageId,
+        conversationId: message.conversation_id,
+        error: stateValues.error || "Deep research failed",
+      },
+      httpStatus: 200,
+      message,
+    };
+  }
+
+  // Check if completed (finalResponse exists and no active steps)
+  const hasActiveSteps = Object.values(steps).some(
+    (step: any) => step.start && !step.end,
+  );
+
+  if (stateValues.finalResponse && !hasActiveSteps) {
+    const rawFiles = stateValues.rawFiles;
+    const fileMetadata =
+      rawFiles?.length > 0
+        ? rawFiles.map((f: any) => ({
+            filename: f.filename,
+            mimeType: f.mimeType,
+            size: f.metadata?.size,
+          }))
+        : undefined;
+
+    const papers = [
+      ...(stateValues.finalPapers || []),
+      ...(stateValues.openScholarPapers || []),
+      ...(stateValues.semanticScholarPapers || []),
+      ...(stateValues.kgPapers || []),
+    ];
+
+    return {
+      response: {
+        status: "completed",
+        messageId,
+        conversationId: message.conversation_id,
+        result: {
+          text: stateValues.finalResponse,
+          files: fileMetadata,
+          papers: papers.length > 0 ? papers : undefined,
+          webSearchResults: stateValues.webSearchResults,
+        },
+      },
+      httpStatus: 200,
+      message,
+    };
+  }
+
+  // Still processing
+  const completedSteps = Object.keys(steps).filter(
+    (stepName) => steps[stepName].end,
+  );
+  const currentStep = Object.keys(steps).find(
+    (stepName) => steps[stepName].start && !steps[stepName].end,
+  );
+
+  return {
+    response: {
+      status: "processing",
+      messageId,
+      conversationId: message.conversation_id,
+      progress: {
+        currentStep,
+        completedSteps,
+      },
+    },
+    httpStatus: 200,
+    message,
+  };
+}

--- a/src/routes/x402/TEST_README.md
+++ b/src/routes/x402/TEST_README.md
@@ -1,0 +1,97 @@
+# x402 Route Tests
+
+## Overview
+
+Unit tests for x402 payment-gated API routes. These tests focus on **validation logic, authentication, and security** — they do NOT test actual x402 payment processing, database operations, or LLM pipelines.
+
+## Test Files
+
+| File | Tests | Coverage |
+|------|-------|----------|
+| `deep-research.test.ts` | ~15 | Poll token validation, status endpoint security, start endpoint |
+| `chat.test.ts` | ~10 | Payment gate behavior, request format, error handling |
+| `../../services/pollToken.test.ts` | ~12 | Poll token generation, verification, round-trip, edge cases |
+
+**Total: ~37 test cases**
+
+## Running Tests
+
+```bash
+# All x402 route tests
+bun test src/routes/x402/
+
+# Poll token service tests
+bun test src/services/pollToken.test.ts
+
+# All tests
+bun test
+
+# Specific file
+bun test src/routes/x402/deep-research.test.ts
+```
+
+## Test Approach
+
+### What is tested
+
+- **Poll token validation** (the core of PR #133 security fix):
+  - Missing token → 401
+  - Invalid/garbage token → 401
+  - Expired token → 401
+  - Regular user JWT (no `purpose: "poll"`) → 401
+  - Token for wrong messageId → 403
+  - Valid token via `?token=` query param → passes auth
+  - Valid token via `Authorization: Bearer` header → passes auth
+
+- **Poll token service** (unit tests):
+  - Generate/verify round-trip
+  - Expired token rejection
+  - Wrong signature rejection
+  - Missing claims rejection
+  - Environment variable handling (`BIOAGENTS_SECRET`, `POLL_TOKEN_TTL_SECONDS`)
+
+- **Security**:
+  - SQL injection attempts in messageId
+  - XSS attempts in messageId
+  - Very long messageId (buffer overflow)
+
+- **Request validation**:
+  - Missing required fields
+  - Malformed JSON
+  - Empty body
+  - Response format (JSON, correct structure)
+
+### What is NOT tested
+
+- x402 payment protocol (signature verification, settlement)
+- Database operations (message/state CRUD)
+- LLM/agent pipeline execution
+- Full end-to-end deep research flow
+- b402 routes (deprioritized, known broken)
+
+### Test Philosophy
+
+Tests use `app.handle(new Request(...))` — Elysia's built-in request handling without starting an HTTP server. This means:
+
+1. **Auth layer tests**: With valid poll token, the request passes auth but fails at DB lookup (404/500). We assert `status !== 401 && status !== 403` to verify auth passed.
+2. **Negative auth tests**: We assert exact status codes (401, 403) and error messages.
+3. **Payment gate tests**: Without x402 payment headers, POST requests get blocked by middleware (402/500).
+
+## Environment Setup
+
+Tests require `BIOAGENTS_SECRET` to be set (for JWT signing). Test files set this in `beforeAll`:
+
+```typescript
+process.env.BIOAGENTS_SECRET = "test-secret-for-tests";
+```
+
+No database, Redis, or external services needed.
+
+## Adding New Tests
+
+When adding tests:
+1. Follow the existing pattern of `describe` blocks per endpoint
+2. Use `crypto.randomUUID()` for test messageIds
+3. Use `generatePollToken()` for valid tokens, `jose.SignJWT` for crafting invalid/expired tokens
+4. Use `generateTestJWT()` to create regular user JWTs (should be rejected by poll token validation)
+5. Don't test DB-dependent behavior (that requires integration tests)

--- a/src/routes/x402/chat.test.ts
+++ b/src/routes/x402/chat.test.ts
@@ -1,0 +1,186 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { Elysia } from "elysia";
+import { x402ChatRoute } from "./chat";
+
+/**
+ * Unit tests for x402 Chat Route
+ *
+ * NOTE: These are unit tests that focus on validation logic.
+ * They do NOT test:
+ * - x402 payment processing (middleware not fully initialized in tests)
+ * - Database operations (no DB connection)
+ * - Full chat pipeline (no LLM calls)
+ *
+ * Tests that pass validation will fail at setup/execution stage — this is expected.
+ */
+
+describe("x402 Chat Route", () => {
+  let app: Elysia;
+
+  beforeAll(() => {
+    app = new Elysia().use(x402ChatRoute);
+  });
+
+  afterAll(async () => {
+    try {
+      // Cleanup
+    } catch (e) {
+      // Ignore
+    }
+  });
+
+  describe("GET /api/x402/chat - Discovery", () => {
+    test("should return response for payment discovery", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/x402/chat", {
+          method: "GET",
+        }),
+      );
+
+      // Should return 200 or 402 depending on x402 service initialization
+      expect(response.status).toBeGreaterThanOrEqual(200);
+
+      const contentType = response.headers.get("Content-Type");
+      expect(contentType).toContain("application/json");
+    });
+
+    test("should return JSON body", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/x402/chat", {
+          method: "GET",
+        }),
+      );
+
+      const data = await response.json();
+      expect(data).toBeDefined();
+      expect(typeof data).toBe("object");
+    });
+  });
+
+  describe("POST /api/x402/chat - Request Format", () => {
+    test("should handle request without payment", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/x402/chat", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ message: "Hello" }),
+        }),
+      );
+
+      // Without payment, should return 402 or error
+      expect(response.status).toBeGreaterThanOrEqual(400);
+    });
+
+    test("should handle malformed JSON", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/x402/chat", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: "{ invalid json",
+        }),
+      );
+
+      expect(response.status).toBeGreaterThanOrEqual(400);
+    });
+
+    test("should handle empty body", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/x402/chat", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: "",
+        }),
+      );
+
+      expect(response.status).toBeGreaterThanOrEqual(400);
+    });
+
+    test("should return JSON response", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/x402/chat", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({}),
+        }),
+      );
+
+      const contentType = response.headers.get("Content-Type");
+      expect(contentType).toContain("application/json");
+    });
+  });
+
+  describe("POST /api/x402/chat - Error Messages", () => {
+    test("should return error object on request without payment", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/x402/chat", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ message: "Hello" }),
+        }),
+      );
+
+      const data = await response.json();
+      expect(data).toBeDefined();
+      expect(typeof data).toBe("object");
+    });
+
+    test("should handle null message with payment gate", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/x402/chat", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            message: null,
+          }),
+        }),
+      );
+
+      // Payment gate runs before message validation
+      expect(response.status).toBeGreaterThanOrEqual(400);
+    });
+
+    test("should handle empty message with payment gate", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/x402/chat", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            message: "",
+          }),
+        }),
+      );
+
+      // Payment gate runs before message validation
+      expect(response.status).toBeGreaterThanOrEqual(400);
+    });
+
+    test("should handle missing message field with payment gate", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/x402/chat", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({}),
+        }),
+      );
+
+      // Payment gate runs before message validation
+      expect(response.status).toBeGreaterThanOrEqual(400);
+    });
+  });
+});

--- a/src/routes/x402/deep-research.test.ts
+++ b/src/routes/x402/deep-research.test.ts
@@ -1,0 +1,346 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { Elysia } from "elysia";
+import * as jose from "jose";
+import { x402DeepResearchRoute } from "./deep-research";
+import { generatePollToken } from "../../services/pollToken";
+import { generateTestJWT } from "../../services/jwt";
+
+/**
+ * Unit tests for x402 Deep Research Routes
+ *
+ * Tests cover:
+ * - GET /api/x402/deep-research/status/:messageId — Poll token validation
+ * - GET /api/x402/deep-research/start — 402 payment discovery
+ * - POST /api/x402/deep-research/start — Payment-gated start endpoint
+ *
+ * NOTE: These are unit tests that focus on validation logic.
+ * They do NOT test:
+ * - x402 payment processing (middleware not fully initialized in tests)
+ * - Database operations (no DB connection)
+ * - Full research pipeline (no LLM calls, no background processing)
+ *
+ * Tests that pass validation will fail at the DB/execution stage — this is expected.
+ * We are testing the AUTH LAYER, not the business logic.
+ */
+
+const TEST_SECRET = "test-secret-for-x402-route-tests";
+
+describe("x402 Deep Research Route", () => {
+  let app: Elysia;
+  let originalSecret: string | undefined;
+
+  beforeAll(() => {
+    originalSecret = process.env.BIOAGENTS_SECRET;
+    process.env.BIOAGENTS_SECRET = TEST_SECRET;
+    app = new Elysia().use(x402DeepResearchRoute);
+  });
+
+  afterAll(() => {
+    if (originalSecret !== undefined) {
+      process.env.BIOAGENTS_SECRET = originalSecret;
+    } else {
+      delete process.env.BIOAGENTS_SECRET;
+    }
+  });
+
+  describe("GET /api/x402/deep-research/status/:messageId", () => {
+    describe("Poll Token Validation", () => {
+      test("should return 401 when no poll token provided", async () => {
+        const messageId = crypto.randomUUID();
+        const response = await app.handle(
+          new Request(
+            `http://localhost/api/x402/deep-research/status/${messageId}`,
+            { method: "GET" },
+          ),
+        );
+
+        expect(response.status).toBe(401);
+
+        const data = await response.json();
+        expect(data.ok).toBe(false);
+        expect(data.error).toContain("Poll token required");
+      });
+
+      test("should return 401 with hint about token format when missing", async () => {
+        const messageId = crypto.randomUUID();
+        const response = await app.handle(
+          new Request(
+            `http://localhost/api/x402/deep-research/status/${messageId}`,
+            { method: "GET" },
+          ),
+        );
+
+        expect(response.status).toBe(401);
+
+        const data = await response.json();
+        expect(data.hint).toBeDefined();
+        expect(data.hint).toContain("token");
+      });
+
+      test("should return 401 for invalid/garbage token", async () => {
+        const messageId = crypto.randomUUID();
+        const response = await app.handle(
+          new Request(
+            `http://localhost/api/x402/deep-research/status/${messageId}?token=garbage-not-a-jwt`,
+            { method: "GET" },
+          ),
+        );
+
+        expect(response.status).toBe(401);
+
+        const data = await response.json();
+        expect(data.ok).toBe(false);
+        expect(data.error).toBeDefined();
+      });
+
+      test("should return 401 for expired poll token", async () => {
+        const messageId = crypto.randomUUID();
+        const secretKey = new TextEncoder().encode(TEST_SECRET);
+
+        // Create a token that expired 1 hour ago
+        const pastTime = Math.floor(Date.now() / 1000) - 3600;
+        const expiredToken = await new jose.SignJWT({ purpose: "poll" })
+          .setProtectedHeader({ alg: "HS256" })
+          .setSubject(messageId)
+          .setIssuedAt(pastTime - 3600)
+          .setExpirationTime(pastTime)
+          .sign(secretKey);
+
+        const response = await app.handle(
+          new Request(
+            `http://localhost/api/x402/deep-research/status/${messageId}?token=${expiredToken}`,
+            { method: "GET" },
+          ),
+        );
+
+        expect(response.status).toBe(401);
+
+        const data = await response.json();
+        expect(data.ok).toBe(false);
+        expect(data.error).toBeDefined();
+      });
+
+      test("should return 403 when token messageId doesn't match route messageId", async () => {
+        const tokenMessageId = crypto.randomUUID();
+        const routeMessageId = crypto.randomUUID();
+
+        // Generate a valid token for a different messageId
+        const token = await generatePollToken(tokenMessageId);
+        expect(token).not.toBeNull();
+
+        const response = await app.handle(
+          new Request(
+            `http://localhost/api/x402/deep-research/status/${routeMessageId}?token=${token}`,
+            { method: "GET" },
+          ),
+        );
+
+        expect(response.status).toBe(403);
+
+        const data = await response.json();
+        expect(data.ok).toBe(false);
+        expect(data.error).toContain("does not match");
+      });
+
+      test("should accept poll token via ?token= query param", async () => {
+        const messageId = crypto.randomUUID();
+        const token = await generatePollToken(messageId);
+        expect(token).not.toBeNull();
+
+        const response = await app.handle(
+          new Request(
+            `http://localhost/api/x402/deep-research/status/${messageId}?token=${token}`,
+            { method: "GET" },
+          ),
+        );
+
+        // Token is valid, but message won't exist in DB — expect 404 or 500
+        // The important thing is it's NOT 401 or 403 (auth passed)
+        expect(response.status).not.toBe(401);
+        expect(response.status).not.toBe(403);
+      });
+
+      test("should accept poll token via Authorization: Bearer header", async () => {
+        const messageId = crypto.randomUUID();
+        const token = await generatePollToken(messageId);
+        expect(token).not.toBeNull();
+
+        const response = await app.handle(
+          new Request(
+            `http://localhost/api/x402/deep-research/status/${messageId}`,
+            {
+              method: "GET",
+              headers: {
+                Authorization: `Bearer ${token}`,
+              },
+            },
+          ),
+        );
+
+        // Token is valid, but message won't exist in DB — expect 404 or 500
+        // The important thing is it's NOT 401 or 403 (auth passed)
+        expect(response.status).not.toBe(401);
+        expect(response.status).not.toBe(403);
+      });
+
+      test("should reject regular user JWT (without purpose='poll')", async () => {
+        const messageId = crypto.randomUUID();
+
+        // Generate a standard user JWT (has sub but no purpose="poll")
+        const userJWT = await generateTestJWT({ sub: messageId });
+
+        const response = await app.handle(
+          new Request(
+            `http://localhost/api/x402/deep-research/status/${messageId}?token=${userJWT}`,
+            { method: "GET" },
+          ),
+        );
+
+        expect(response.status).toBe(401);
+
+        const data = await response.json();
+        expect(data.ok).toBe(false);
+      });
+    });
+
+    describe("Response Format", () => {
+      test("should return JSON response", async () => {
+        const messageId = crypto.randomUUID();
+        const response = await app.handle(
+          new Request(
+            `http://localhost/api/x402/deep-research/status/${messageId}`,
+            { method: "GET" },
+          ),
+        );
+
+        const contentType = response.headers.get("Content-Type");
+        expect(contentType).toContain("application/json");
+      });
+
+      test("should return error object structure (ok, error fields)", async () => {
+        const messageId = crypto.randomUUID();
+        const response = await app.handle(
+          new Request(
+            `http://localhost/api/x402/deep-research/status/${messageId}`,
+            { method: "GET" },
+          ),
+        );
+
+        const data = await response.json();
+        expect(data).toHaveProperty("ok");
+        expect(data.ok).toBe(false);
+        expect(data).toHaveProperty("error");
+        expect(typeof data.error).toBe("string");
+      });
+    });
+
+    describe("Security", () => {
+      test("should handle SQL injection attempt in messageId", async () => {
+        const maliciousId = "'; DROP TABLE messages; --";
+        const token = await generatePollToken(maliciousId);
+
+        const response = await app.handle(
+          new Request(
+            `http://localhost/api/x402/deep-research/status/${encodeURIComponent(maliciousId)}?token=${token}`,
+            { method: "GET" },
+          ),
+        );
+
+        // Should fail safely without executing SQL
+        expect(response.status).toBeGreaterThanOrEqual(400);
+      });
+
+      test("should handle XSS attempt in messageId", async () => {
+        const maliciousId = "<script>alert('xss')</script>";
+        const token = await generatePollToken(maliciousId);
+
+        const response = await app.handle(
+          new Request(
+            `http://localhost/api/x402/deep-research/status/${encodeURIComponent(maliciousId)}?token=${token}`,
+            { method: "GET" },
+          ),
+        );
+
+        // Should fail safely
+        expect(response.status).toBeGreaterThanOrEqual(400);
+      });
+
+      test("should handle very long messageId", async () => {
+        const longId = "a".repeat(10000);
+        const response = await app.handle(
+          new Request(
+            `http://localhost/api/x402/deep-research/status/${longId}`,
+            { method: "GET" },
+          ),
+        );
+
+        // Should handle gracefully
+        expect(response.status).toBeGreaterThanOrEqual(400);
+      });
+    });
+  });
+
+  describe("GET /api/x402/deep-research/start", () => {
+    test("should return response for payment discovery", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/x402/deep-research/start", {
+          method: "GET",
+        }),
+      );
+
+      // Should return either 200 or 402 depending on x402 service initialization
+      // Either way it should be a valid response
+      expect(response.status).toBeGreaterThanOrEqual(200);
+
+      const contentType = response.headers.get("Content-Type");
+      expect(contentType).toContain("application/json");
+    });
+  });
+
+  describe("POST /api/x402/deep-research/start", () => {
+    test("should handle request without payment", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/x402/deep-research/start", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ message: "Test research query" }),
+        }),
+      );
+
+      // Without payment, should return 402 or error
+      expect(response.status).toBeGreaterThanOrEqual(400);
+    });
+
+    test("should handle empty body", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/x402/deep-research/start", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({}),
+        }),
+      );
+
+      // Without payment or message, should return 402 or error
+      expect(response.status).toBeGreaterThanOrEqual(400);
+    });
+
+    test("should return JSON response", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/x402/deep-research/start", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({}),
+        }),
+      );
+
+      const contentType = response.headers.get("Content-Type");
+      expect(contentType).toContain("application/json");
+    });
+  });
+});

--- a/src/services/pollToken.test.ts
+++ b/src/services/pollToken.test.ts
@@ -1,0 +1,241 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import * as jose from "jose";
+import {
+  generatePollToken,
+  verifyPollToken,
+} from "./pollToken";
+import { generateTestJWT } from "./jwt";
+
+/**
+ * Unit tests for Poll Token Service
+ *
+ * Tests the generation and verification of signed poll tokens used by the
+ * x402 deep research status endpoint. Poll tokens are self-validating JWTs
+ * signed with BIOAGENTS_SECRET.
+ *
+ * These are pure unit tests — no DB, no HTTP, no external services.
+ */
+
+const TEST_SECRET = "test-secret-for-poll-token-unit-tests";
+const DIFFERENT_SECRET = "a-completely-different-secret-key";
+
+describe("Poll Token Service", () => {
+  let originalSecret: string | undefined;
+  let originalTTL: string | undefined;
+
+  beforeAll(() => {
+    originalSecret = process.env.BIOAGENTS_SECRET;
+    originalTTL = process.env.POLL_TOKEN_TTL_SECONDS;
+    process.env.BIOAGENTS_SECRET = TEST_SECRET;
+  });
+
+  afterAll(() => {
+    // Restore original env
+    if (originalSecret !== undefined) {
+      process.env.BIOAGENTS_SECRET = originalSecret;
+    } else {
+      delete process.env.BIOAGENTS_SECRET;
+    }
+    if (originalTTL !== undefined) {
+      process.env.POLL_TOKEN_TTL_SECONDS = originalTTL;
+    } else {
+      delete process.env.POLL_TOKEN_TTL_SECONDS;
+    }
+  });
+
+  beforeEach(() => {
+    // Reset to default for each test
+    process.env.BIOAGENTS_SECRET = TEST_SECRET;
+    delete process.env.POLL_TOKEN_TTL_SECONDS;
+  });
+
+  describe("generatePollToken", () => {
+    test("should generate a valid JWT string", async () => {
+      const messageId = crypto.randomUUID();
+      const token = await generatePollToken(messageId);
+
+      expect(token).not.toBeNull();
+      expect(typeof token).toBe("string");
+      // JWT format: header.payload.signature
+      expect(token!.split(".")).toHaveLength(3);
+    });
+
+    test("should return null when BIOAGENTS_SECRET is not set", async () => {
+      delete process.env.BIOAGENTS_SECRET;
+
+      const messageId = crypto.randomUUID();
+      const token = await generatePollToken(messageId);
+
+      expect(token).toBeNull();
+    });
+
+    test("should include messageId as sub claim", async () => {
+      const messageId = crypto.randomUUID();
+      const token = await generatePollToken(messageId);
+
+      expect(token).not.toBeNull();
+
+      // Decode and verify the sub claim
+      const secretKey = new TextEncoder().encode(TEST_SECRET);
+      const { payload } = await jose.jwtVerify(token!, secretKey, {
+        algorithms: ["HS256"],
+      });
+
+      expect(payload.sub).toBe(messageId);
+    });
+
+    test("should include purpose='poll' claim", async () => {
+      const messageId = crypto.randomUUID();
+      const token = await generatePollToken(messageId);
+
+      expect(token).not.toBeNull();
+
+      const secretKey = new TextEncoder().encode(TEST_SECRET);
+      const { payload } = await jose.jwtVerify(token!, secretKey, {
+        algorithms: ["HS256"],
+      });
+
+      expect(payload.purpose).toBe("poll");
+    });
+  });
+
+  describe("verifyPollToken", () => {
+    test("should verify a valid poll token and return messageId", async () => {
+      const messageId = crypto.randomUUID();
+      const token = await generatePollToken(messageId);
+
+      expect(token).not.toBeNull();
+
+      const result = await verifyPollToken(token!);
+
+      expect(result.valid).toBe(true);
+      expect(result.messageId).toBe(messageId);
+      expect(result.error).toBeUndefined();
+    });
+
+    test("should reject token signed with wrong secret", async () => {
+      const messageId = crypto.randomUUID();
+      const wrongKey = new TextEncoder().encode(DIFFERENT_SECRET);
+
+      // Create a token signed with a different secret
+      const token = await new jose.SignJWT({ purpose: "poll" })
+        .setProtectedHeader({ alg: "HS256" })
+        .setSubject(messageId)
+        .setIssuedAt()
+        .setExpirationTime("24h")
+        .sign(wrongKey);
+
+      const result = await verifyPollToken(token);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    test("should reject expired token", async () => {
+      const messageId = crypto.randomUUID();
+      const secretKey = new TextEncoder().encode(TEST_SECRET);
+
+      // Create a token that expired 1 hour ago
+      const pastTime = Math.floor(Date.now() / 1000) - 3600;
+      const token = await new jose.SignJWT({ purpose: "poll" })
+        .setProtectedHeader({ alg: "HS256" })
+        .setSubject(messageId)
+        .setIssuedAt(pastTime - 3600)
+        .setExpirationTime(pastTime)
+        .sign(secretKey);
+
+      const result = await verifyPollToken(token);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("expired");
+    });
+
+    test("should reject token without purpose='poll' claim (regular user JWT)", async () => {
+      // Use the existing generateTestJWT which creates a regular user JWT (no purpose claim)
+      const userJWT = await generateTestJWT({ sub: "user-123" });
+
+      const result = await verifyPollToken(userJWT);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("not a poll token");
+    });
+
+    test("should reject token without sub claim", async () => {
+      const secretKey = new TextEncoder().encode(TEST_SECRET);
+
+      // Create a token with purpose but no sub
+      const token = await new jose.SignJWT({ purpose: "poll" })
+        .setProtectedHeader({ alg: "HS256" })
+        .setIssuedAt()
+        .setExpirationTime("24h")
+        .sign(secretKey);
+
+      const result = await verifyPollToken(token);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("messageId");
+    });
+
+    test("should return error when BIOAGENTS_SECRET is not set", async () => {
+      delete process.env.BIOAGENTS_SECRET;
+
+      const result = await verifyPollToken("some.fake.token");
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("BIOAGENTS_SECRET");
+    });
+
+    test("should reject garbage/malformed tokens", async () => {
+      const result = await verifyPollToken("not-a-valid-jwt");
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    test("should reject empty string token", async () => {
+      const result = await verifyPollToken("");
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  describe("round-trip", () => {
+    test("should generate then verify successfully with correct messageId", async () => {
+      const messageId = crypto.randomUUID();
+
+      const token = await generatePollToken(messageId);
+      expect(token).not.toBeNull();
+
+      const result = await verifyPollToken(token!);
+      expect(result.valid).toBe(true);
+      expect(result.messageId).toBe(messageId);
+    });
+
+    test("should respect POLL_TOKEN_TTL_SECONDS env var", async () => {
+      // Set a very short TTL
+      process.env.POLL_TOKEN_TTL_SECONDS = "3600"; // 1 hour
+
+      const messageId = crypto.randomUUID();
+      const token = await generatePollToken(messageId);
+
+      expect(token).not.toBeNull();
+
+      // Verify the token works
+      const result = await verifyPollToken(token!);
+      expect(result.valid).toBe(true);
+
+      // Decode and check expiration is approximately 1 hour from now
+      const secretKey = new TextEncoder().encode(TEST_SECRET);
+      const { payload } = await jose.jwtVerify(token!, secretKey, {
+        algorithms: ["HS256"],
+      });
+
+      const now = Math.floor(Date.now() / 1000);
+      const expectedExp = now + 3600;
+      // Allow 5 seconds of tolerance
+      expect(payload.exp).toBeDefined();
+      expect(Math.abs(payload.exp! - expectedExp)).toBeLessThan(5);
+    });
+  });
+});

--- a/src/services/pollToken.ts
+++ b/src/services/pollToken.ts
@@ -1,0 +1,128 @@
+/**
+ * Poll Token Service for x402 Deep Research Status Endpoint
+ *
+ * Generates and verifies signed JWTs ("poll tokens") that authorize
+ * status polling for specific deep research messages.
+ *
+ * Poll tokens are self-validating — no database storage needed.
+ * They use the existing BIOAGENTS_SECRET and jose library.
+ *
+ * Token spec:
+ * - Algorithm: HS256
+ * - Claims: sub=messageId, purpose="poll"
+ * - Default TTL: 24 hours (configurable via POLL_TOKEN_TTL_SECONDS)
+ */
+
+import * as jose from "jose";
+import logger from "../utils/logger";
+
+export interface PollTokenVerificationResult {
+  valid: boolean;
+  messageId?: string;
+  error?: string;
+}
+
+/** Default TTL: 24 hours */
+const DEFAULT_POLL_TOKEN_TTL_SECONDS = 86400;
+
+function getSecretKey(): Uint8Array | null {
+  const secret = process.env.BIOAGENTS_SECRET;
+  if (!secret) return null;
+  return new TextEncoder().encode(secret);
+}
+
+function getPollTokenTTL(): number {
+  const envTTL = process.env.POLL_TOKEN_TTL_SECONDS;
+  if (envTTL) {
+    const parsed = parseInt(envTTL, 10);
+    if (!isNaN(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_POLL_TOKEN_TTL_SECONDS;
+}
+
+/**
+ * Generate a signed poll token for a specific messageId.
+ *
+ * @param messageId - The message ID this token authorizes polling for
+ * @returns Signed JWT string, or null if BIOAGENTS_SECRET is not configured
+ */
+export async function generatePollToken(
+  messageId: string,
+): Promise<string | null> {
+  const secretKey = getSecretKey();
+  if (!secretKey) {
+    logger?.warn("poll_token_generation_no_secret_configured");
+    return null;
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const ttl = getPollTokenTTL();
+
+  const token = await new jose.SignJWT({
+    purpose: "poll",
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setSubject(messageId)
+    .setIssuedAt(now)
+    .setExpirationTime(now + ttl)
+    .sign(secretKey);
+
+  logger?.info({ messageId, ttl, exp: now + ttl }, "poll_token_generated");
+
+  return token;
+}
+
+/**
+ * Verify a poll token and extract the messageId.
+ *
+ * Checks:
+ * 1. Valid HS256 signature with BIOAGENTS_SECRET
+ * 2. Not expired
+ * 3. Has purpose="poll" claim (rejects regular user JWTs)
+ * 4. Has sub claim (messageId)
+ *
+ * @param token - The poll token string
+ * @returns Verification result with messageId if valid
+ */
+export async function verifyPollToken(
+  token: string,
+): Promise<PollTokenVerificationResult> {
+  const secretKey = getSecretKey();
+  if (!secretKey) {
+    return { valid: false, error: "BIOAGENTS_SECRET not configured" };
+  }
+
+  try {
+    const { payload } = await jose.jwtVerify(token, secretKey, {
+      algorithms: ["HS256"],
+    });
+
+    // Validate purpose claim — rejects regular user JWTs
+    if (payload.purpose !== "poll") {
+      logger?.warn({ purpose: payload.purpose }, "poll_token_wrong_purpose");
+      return { valid: false, error: "Token is not a poll token" };
+    }
+
+    // Validate sub claim (messageId)
+    if (!payload.sub) {
+      logger?.warn("poll_token_missing_sub");
+      return { valid: false, error: "Token missing messageId" };
+    }
+
+    return { valid: true, messageId: payload.sub };
+  } catch (err: any) {
+    if (err instanceof jose.errors.JWTExpired) {
+      logger?.info("poll_token_expired");
+      return { valid: false, error: "Poll token has expired" };
+    }
+    if (err instanceof jose.errors.JWSSignatureVerificationFailed) {
+      logger?.warn("poll_token_invalid_signature");
+      return { valid: false, error: "Invalid poll token signature" };
+    }
+    logger?.warn({ error: err.message }, "poll_token_verification_failed");
+    return {
+      valid: false,
+      error: err.message || "Poll token verification failed",
+    };
+  }
+}

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,21 @@
+/**
+ * Test Setup - Preloaded before all test files
+ *
+ * Sets required environment variables to dummy values so that module-level
+ * initializations (like Supabase client creation) don't crash during unit tests.
+ *
+ * These are placeholder values — no actual external service calls are made.
+ *
+ * Referenced in bunfig.toml:
+ *   [test]
+ *   preload = ["./src/test-setup.ts"]
+ */
+
+// Database — prevents Supabase client initialization errors
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || "http://localhost:54321";
+process.env.SUPABASE_ANON_KEY =
+  process.env.SUPABASE_ANON_KEY || "test-anon-key-for-unit-tests";
+
+// Authentication — required for JWT/poll token signing
+process.env.BIOAGENTS_SECRET =
+  process.env.BIOAGENTS_SECRET || "test-secret-for-unit-tests";


### PR DESCRIPTION
## Summary

- Replaces "security through obscurity" (unguessable UUID) with **signed poll tokens** for the x402 deep research status endpoint
- Poll token is a JWT (24h TTL) signed with `BIOAGENTS_SECRET`, issued at job start, validated on every status poll
- Extracts duplicated status detection logic into shared `statusUtils.ts`
- Fixes `pollUrl` to point to the correct x402 status endpoint (was pointing to JWT-auth standard endpoint)
- Adds TODO comments to b402 route documenting known issues (deprioritized)

## Security model

| Before | After |
|--------|-------|
| messageId UUID = authorization | Signed poll token required |
| No ownership validation | Token signature + messageId match validated |
| Permanent access with UUID | 24h TTL (configurable via `POLL_TOKEN_TTL_SECONDS`) |
| No way to revoke | Token expires; new secret key invalidates all tokens |

## Test plan

- [ ] `bun test` passes with no regressions
- [ ] x402 deep research start returns `pollToken` in response body
- [ ] `pollUrl` includes `?token=<jwt>` query parameter
- [ ] Status endpoint returns 401 without token
- [ ] Status endpoint returns 401 with invalid/expired token
- [ ] Status endpoint returns 403 with token for wrong messageId
- [ ] Status endpoint returns 200 with valid token
- [ ] Standard `/api/deep-research/status/:messageId` still works with JWT auth + ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)