### PR TITLE
Fix paper generation Unicode font support and BibTeX underscore escaping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   latexmk \
   pandoc \
   lmodern \
+  fonts-linuxlibertine \
   && update-ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 

--- a/src/services/paper/convert/pandocConvert.ts
+++ b/src/services/paper/convert/pandocConvert.ts
@@ -66,7 +66,7 @@ export async function pandocConvert(
 function patchForXelatex(tex: string): string {
   let result = tex;
 
-  // Replace \usepackage[utf8]{inputenc} with fontspec (XeLaTeX)
+  // For older Pandoc: replace inputenc with fontspec (XeLaTeX native Unicode)
   result = result.replace(
     /\\usepackage\[utf8\]\{inputenc\}/g,
     "\\usepackage{fontspec}",
@@ -74,6 +74,14 @@ function patchForXelatex(tex: string): string {
 
   // Remove \usepackage[T1]{fontenc} — XeLaTeX uses fontspec instead
   result = result.replace(/\\usepackage\[T1\]\{fontenc\}\n?/g, "");
+
+  // Replace Latin Modern with Linux Libertine for full Unicode support
+  // (Greek, math operators, superscripts/subscripts — 2000+ glyphs)
+  // Latin Modern lacks glyphs for direct Unicode Greek (κ,γ,η,etc.) and math symbols (≈,≤,≥,etc.)
+  result = result.replace(
+    /\\usepackage\{lmodern\}/g,
+    "\\setmainfont{Linux Libertine O}\n\\setsansfont{Linux Biolinum O}",
+  );
 
   // Ensure graphicspath is set for figures
   if (!result.includes("\\graphicspath")) {


### PR DESCRIPTION
Replace Latin Modern with Linux Libertine O font which has full Unicode coverage (2000+ glyphs: Greek, math operators, superscripts/subscripts). Latin Modern was missing glyphs for direct Unicode characters (κ,γ,η,α,β, ≈,≤,≥,⁵,⁷,⁻) causing "Missing character" errors during XeLaTeX compilation.

Also escape unescaped underscores in BibTeX text field values from DOI resolvers (e.g., gene names like vb_paep_ya3) which caused "Missing $ inserted" LaTeX errors in the .bbl output.