### PR TITLE
Capture real-time reasoning traces from bio agents

### DIFF
--- a/src/services/queue/workers/deep-research.worker.ts
+++ b/src/services/queue/workers/deep-research.worker.ts
@@ -429,7 +429,7 @@ async function processDeepResearchJob(
     const taskPromises = tasksToExecute.map(async (task) => {
       // Callback to persist reasoning traces to conversation state on each poll
       const onPollUpdate: OnPollUpdate = async ({ reasoning }) => {
-        if (reasoning) {
+        if (reasoning && reasoning.length !== (task.reasoning?.length ?? 0)) {
           task.reasoning = reasoning;
           if (conversationState.id) {
             await writeStateSerialized();

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -46,8 +46,11 @@ export type PlanTask = {
   start?: string;
   end?: string;
   output?: string;
+  reasoning?: string[]; // Real-time reasoning trace from external agent (updated during polling)
   artifacts?: Array<AnalysisArtifact>;
 };
+
+export type OnPollUpdate = (update: { reasoning?: string[] }) => void | Promise<void>;
 
 // Conversation state values interface (extends StateValues with persistent data)
 export interface ConversationStateValues extends StateValues {


### PR DESCRIPTION
## Summary
- Thread `onPollUpdate` callback through literature and analysis agent layers to capture `reasoning` (string[]) from external API poll responses
- Persist reasoning traces to `PlanTask.reasoning` in conversation state and notify WebSocket clients on every 10s poll iteration
- Works in both queue mode (worker) and in-process mode (start route)

## Test plan
- [ ] Verify `bun test` / `tsc --noEmit` pass with no new errors
- [ ] Trigger deep research with BIO primary agent, confirm `reasoning` appears in `conversation_states.values.plan[].reasoning`
- [ ] Confirm WebSocket `state:updated` notifications fire during polling
- [ ] Verify existing call sites without `onPollUpdate` still work (param is optional)