### PR TITLE
feat: add CLARITY subagent for Clarity Protocol integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,15 @@ DATA_ANALYSIS_API_URL=
 DATA_ANALYSIS_API_KEY=
 
 # ============================================================================
+# Clarity Protocol Integration
+# ============================================================================
+# Clarity Protocol provides protein fold predictions, clinical annotations,
+# and AI agent research findings for disease-linked protein variants.
+# API docs: https://clarityprotocol.io/api/v1/info
+CLARITY_API_URL=https://clarityprotocol.io/api/v1
+CLARITY_API_KEY=            # Optional, for higher rate limits
+
+# ============================================================================
 # Task Timeout Configuration (in minutes)
 # ============================================================================
 # Timeout for Bio data analysis tasks (default: 60 minutes)

--- a/.env.worker.example
+++ b/.env.worker.example
@@ -55,6 +55,12 @@ PRIMARY_LITERATURE_AGENT=
 PRIMARY_ANALYSIS_AGENT=
 
 # --------------------------------------------------------------------------
+# OPTIONAL: Clarity Protocol (protein fold + clinical data)
+# --------------------------------------------------------------------------
+CLARITY_API_URL=https://clarityprotocol.io/api/v1
+CLARITY_API_KEY=
+
+# --------------------------------------------------------------------------
 # OPTIONAL: Embeddings
 # --------------------------------------------------------------------------
 EMBEDDING_PROVIDER=openai

--- a/src/agents/clarification/prompts.ts
+++ b/src/agents/clarification/prompts.ts
@@ -122,7 +122,7 @@ Return a JSON object with this exact structure:
   "initialTasks": [
     {
       "objective": "Specific task objective",
-      "type": "LITERATURE" | "ANALYSIS",
+      "type": "LITERATURE" | "ANALYSIS" | "CLARITY",
       "datasetFilenames": ["exact_filename.csv"]
     }
   ]
@@ -183,7 +183,7 @@ Return a JSON object with this exact structure:
   "initialTasks": [
     {
       "objective": "Specific task objective",
-      "type": "LITERATURE" | "ANALYSIS",
+      "type": "LITERATURE" | "ANALYSIS" | "CLARITY",
       "datasetFilenames": ["exact_filename.csv"]
     }
   ]

--- a/src/agents/clarity/api.ts
+++ b/src/agents/clarity/api.ts
@@ -1,0 +1,243 @@
+import { fetchWithRetry } from "../../utils/fetchWithRetry";
+import logger from "../../utils/logger";
+
+// Types for Clarity Protocol API responses
+
+export type ClarityVariantSummary = {
+  id: number;
+  protein_name: string;
+  disease_category: string;
+  overall_confidence: number;
+  plddt_average: number | null;
+  created_at: string;
+};
+
+export type ClarityVariantDetail = {
+  id: number;
+  protein_name: string;
+  disease_category: string;
+  overall_confidence: number;
+  plddt_average: number | null;
+  plddt_very_high: number | null;
+  plddt_confident: number | null;
+  plddt_low: number | null;
+  plddt_very_low: number | null;
+  ai_summary: string | null;
+  research_brief: string | null;
+  created_at: string;
+  updated_at: string | null;
+};
+
+export type ClarityFinding = {
+  id: number;
+  fold_id: number;
+  agent_type: string;
+  finding_type: string;
+  title: string;
+  content: string;
+  source_url: string | null;
+  created_at: string;
+};
+
+export type ClarityAnnotation = {
+  id: number;
+  fold_id: number;
+  agent_id: string;
+  annotation_type: string;
+  content: string;
+  confidence: string;
+  created_at: string;
+};
+
+export type ClarityClinicalData = {
+  gene: string;
+  variant: string;
+  clinvar: {
+    clinical_significance: string | null;
+    review_status: string | null;
+    last_evaluated: string | null;
+    conditions: string[];
+  } | null;
+  gnomad: {
+    allele_frequency: number | null;
+    homozygote_count: number | null;
+    allele_count: number | null;
+    allele_number: number | null;
+  } | null;
+};
+
+function getBaseUrl(): string {
+  return (
+    process.env.CLARITY_API_URL?.replace(/\/$/, "") ||
+    "https://clarityprotocol.io/api/v1"
+  );
+}
+
+function getHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  const apiKey = process.env.CLARITY_API_KEY;
+  if (apiKey) {
+    headers["X-API-Key"] = apiKey;
+  }
+  return headers;
+}
+
+/**
+ * Search for variants by protein name.
+ * GET /api/v1/variants?protein_name={protein}
+ */
+export async function searchVariants(
+  proteinName: string,
+): Promise<ClarityVariantSummary[]> {
+  const baseUrl = getBaseUrl();
+  const url = `${baseUrl}/variants?protein_name=${encodeURIComponent(proteinName)}`;
+
+  logger.info({ proteinName, url }, "clarity_searching_variants");
+
+  const { response } = await fetchWithRetry(url, {
+    method: "GET",
+    headers: getHeaders(),
+  }, {
+    maxRetries: 3,
+    initialDelayMs: 2000,
+    onRetry: (attempt, error) =>
+      logger.warn({ attempt, proteinName, error: error.message }, "clarity_search_variants_retry"),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Clarity API error searching variants: ${response.status} - ${errorText}`);
+  }
+
+  const data = await response.json();
+  return (Array.isArray(data) ? data : data.variants || data.results || []) as ClarityVariantSummary[];
+}
+
+/**
+ * Get full variant detail including AI summary and pLDDT breakdown.
+ * GET /api/v1/variants/{foldId}
+ */
+export async function getVariantDetail(
+  foldId: number,
+): Promise<ClarityVariantDetail> {
+  const baseUrl = getBaseUrl();
+  const url = `${baseUrl}/variants/${foldId}`;
+
+  logger.info({ foldId, url }, "clarity_getting_variant_detail");
+
+  const { response } = await fetchWithRetry(url, {
+    method: "GET",
+    headers: getHeaders(),
+  }, {
+    maxRetries: 3,
+    initialDelayMs: 2000,
+    onRetry: (attempt, error) =>
+      logger.warn({ attempt, foldId, error: error.message }, "clarity_variant_detail_retry"),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Clarity API error getting variant detail: ${response.status} - ${errorText}`);
+  }
+
+  return (await response.json()) as ClarityVariantDetail;
+}
+
+/**
+ * Get agent findings for a variant.
+ * GET /api/v1/variants/{foldId}/findings
+ */
+export async function getFindings(
+  foldId: number,
+): Promise<ClarityFinding[]> {
+  const baseUrl = getBaseUrl();
+  const url = `${baseUrl}/variants/${foldId}/findings`;
+
+  logger.info({ foldId }, "clarity_getting_findings");
+
+  const { response } = await fetchWithRetry(url, {
+    method: "GET",
+    headers: getHeaders(),
+  }, {
+    maxRetries: 3,
+    initialDelayMs: 2000,
+    onRetry: (attempt, error) =>
+      logger.warn({ attempt, foldId, error: error.message }, "clarity_findings_retry"),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Clarity API error getting findings: ${response.status} - ${errorText}`);
+  }
+
+  const data = await response.json();
+  return (Array.isArray(data) ? data : data.findings || []) as ClarityFinding[];
+}
+
+/**
+ * Get structured annotations for a variant.
+ * GET /api/v1/variants/{foldId}/annotations
+ */
+export async function getAnnotations(
+  foldId: number,
+): Promise<ClarityAnnotation[]> {
+  const baseUrl = getBaseUrl();
+  const url = `${baseUrl}/variants/${foldId}/annotations`;
+
+  logger.info({ foldId }, "clarity_getting_annotations");
+
+  const { response } = await fetchWithRetry(url, {
+    method: "GET",
+    headers: getHeaders(),
+  }, {
+    maxRetries: 3,
+    initialDelayMs: 2000,
+    onRetry: (attempt, error) =>
+      logger.warn({ attempt, foldId, error: error.message }, "clarity_annotations_retry"),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Clarity API error getting annotations: ${response.status} - ${errorText}`);
+  }
+
+  const data = await response.json();
+  return (Array.isArray(data) ? data : data.annotations || []) as ClarityAnnotation[];
+}
+
+/**
+ * Get clinical data (ClinVar + gnomAD) for a gene/variant.
+ * GET /api/v1/clinical/{gene}/{variant}
+ */
+export async function getClinicalData(
+  gene: string,
+  variant: string,
+): Promise<ClarityClinicalData | null> {
+  const baseUrl = getBaseUrl();
+  const url = `${baseUrl}/clinical/${encodeURIComponent(gene)}/${encodeURIComponent(variant)}`;
+
+  logger.info({ gene, variant }, "clarity_getting_clinical_data");
+
+  const { response } = await fetchWithRetry(url, {
+    method: "GET",
+    headers: getHeaders(),
+  }, {
+    maxRetries: 3,
+    initialDelayMs: 2000,
+    onRetry: (attempt, error) =>
+      logger.warn({ attempt, gene, variant, error: error.message }, "clarity_clinical_retry"),
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      logger.info({ gene, variant }, "clarity_no_clinical_data");
+      return null;
+    }
+    const errorText = await response.text();
+    throw new Error(`Clarity API error getting clinical data: ${response.status} - ${errorText}`);
+  }
+
+  return (await response.json()) as ClarityClinicalData;
+}

--- a/src/agents/clarity/index.ts
+++ b/src/agents/clarity/index.ts
@@ -1,0 +1,277 @@
+import type { OnPollUpdate } from "../../types/core";
+import logger from "../../utils/logger";
+import {
+  searchVariants,
+  getVariantDetail,
+  getFindings,
+  getAnnotations,
+  getClinicalData,
+} from "./api";
+import { parseVariantFromObjective } from "./parser";
+
+export type ClarityResult = {
+  objective: string;
+  output: string;
+  jobId?: string;
+  reasoning?: string[];
+  start: string;
+  end: string;
+};
+
+/**
+ * Clarity Protocol agent for deep research
+ * Independent agent that queries protein fold data, clinical annotations,
+ * and agent findings from Clarity Protocol's API.
+ *
+ * Flow:
+ * 1. Parse objective to extract protein name and variant
+ * 2. Search Clarity Protocol for matching fold
+ * 3. Fetch variant detail (confidence scores, pLDDT, AI summary)
+ * 4. Fetch agent findings and annotations
+ * 5. Fetch clinical data (ClinVar + gnomAD)
+ * 6. Format all results into structured output
+ */
+export async function clarityAgent(input: {
+  objective: string;
+  onPollUpdate?: OnPollUpdate;
+}): Promise<ClarityResult> {
+  const { objective, onPollUpdate } = input;
+  const start = new Date().toISOString();
+
+  logger.info({ objective }, "clarity_agent_started");
+
+  const reasoning: string[] = [];
+
+  function addReasoning(step: string) {
+    reasoning.push(step);
+    if (onPollUpdate) {
+      try {
+        const result = onPollUpdate({ reasoning });
+        if (result instanceof Promise) {
+          result.catch((err: unknown) =>
+            logger.warn({ err }, "clarity_on_poll_update_failed"),
+          );
+        }
+      } catch (err) {
+        logger.warn({ err }, "clarity_on_poll_update_failed");
+      }
+    }
+  }
+
+  let output: string;
+
+  try {
+    // Step 1: Parse protein and variant from objective
+    const parsed = parseVariantFromObjective(objective);
+    if (!parsed) {
+      output =
+        "Could not extract protein name and variant from the objective. " +
+        "Please specify a protein variant (e.g., 'SOD1 A4V', 'tau P301L').";
+      logger.warn({ objective }, "clarity_agent_no_variant_parsed");
+      return { objective, output, reasoning, start, end: new Date().toISOString() };
+    }
+
+    const { protein, variant } = parsed;
+    addReasoning(`Parsed variant: ${protein} ${variant}`);
+
+    // Step 2: Search for the variant in Clarity Protocol
+    addReasoning(`Searching Clarity Protocol for ${protein} variants...`);
+    const variants = await searchVariants(protein);
+
+    // Find matching variant (protein name may include variant, e.g. "SOD1 A4V")
+    const targetName = `${protein} ${variant}`.toLowerCase();
+    const matchedVariant = variants.find(
+      (v) => v.protein_name.toLowerCase() === targetName,
+    ) || variants.find(
+      (v) => v.protein_name.toLowerCase().includes(variant.toLowerCase()),
+    );
+
+    if (!matchedVariant) {
+      output =
+        `No fold data found for ${protein} ${variant} in Clarity Protocol. ` +
+        `Searched ${variants.length} variant(s) for protein "${protein}". ` +
+        (variants.length > 0
+          ? `Available variants: ${variants.map((v) => v.protein_name).join(", ")}`
+          : "No variants found for this protein.");
+
+      addReasoning(`No matching variant found among ${variants.length} results`);
+      return { objective, output, reasoning, start, end: new Date().toISOString() };
+    }
+
+    const foldId = matchedVariant.id;
+    addReasoning(`Found fold ID ${foldId} for ${matchedVariant.protein_name}`);
+
+    // Steps 3-6: Fetch all data in parallel
+    addReasoning("Fetching variant detail, findings, annotations, and clinical data...");
+
+    const [detail, findings, annotations, clinicalData] = await Promise.all([
+      getVariantDetail(foldId).catch((err) => {
+        logger.error({ err, foldId }, "clarity_variant_detail_failed");
+        return null;
+      }),
+      getFindings(foldId).catch((err) => {
+        logger.error({ err, foldId }, "clarity_findings_failed");
+        return [] as Awaited<ReturnType<typeof getFindings>>;
+      }),
+      getAnnotations(foldId).catch((err) => {
+        logger.error({ err, foldId }, "clarity_annotations_failed");
+        return [] as Awaited<ReturnType<typeof getAnnotations>>;
+      }),
+      getClinicalData(protein, variant).catch((err) => {
+        logger.error({ err, protein, variant }, "clarity_clinical_failed");
+        return null;
+      }),
+    ]);
+
+    addReasoning(
+      `Retrieved: detail=${detail ? "yes" : "no"}, ` +
+      `findings=${findings.length}, annotations=${annotations.length}, ` +
+      `clinical=${clinicalData ? "yes" : "no"}`,
+    );
+
+    // Step 7: Format results
+    output = formatClarityOutput(protein, variant, detail, findings, annotations, clinicalData);
+
+    addReasoning("Formatted Clarity Protocol data into structured output");
+  } catch (err) {
+    logger.error({ err, objective }, "clarity_agent_failed");
+    output = `Error querying Clarity Protocol: ${err instanceof Error ? err.message : "Unknown error"}`;
+  }
+
+  const end = new Date().toISOString();
+
+  logger.info(
+    { objective, outputLength: output.length },
+    "clarity_agent_completed",
+  );
+
+  return {
+    objective,
+    output,
+    reasoning,
+    start,
+    end,
+  };
+}
+
+function formatClarityOutput(
+  protein: string,
+  variant: string,
+  detail: Awaited<ReturnType<typeof getVariantDetail>> | null,
+  findings: Awaited<ReturnType<typeof getFindings>>,
+  annotations: Awaited<ReturnType<typeof getAnnotations>>,
+  clinicalData: Awaited<ReturnType<typeof getClinicalData>> | null,
+): string {
+  const sections: string[] = [];
+
+  sections.push(`# Clarity Protocol Data: ${protein} ${variant}\n`);
+  sections.push(`Source: https://clarityprotocol.io\n`);
+
+  // Fold prediction detail
+  if (detail) {
+    sections.push(`## Structural Prediction (AlphaFold2 via ColabFold)\n`);
+    sections.push(`- **Overall Confidence:** ${(detail.overall_confidence * 100).toFixed(1)}%`);
+    sections.push(`- **Disease Category:** ${detail.disease_category}`);
+
+    if (detail.plddt_average !== null) {
+      sections.push(`- **Mean pLDDT Score:** ${detail.plddt_average.toFixed(1)}`);
+    }
+    if (detail.plddt_very_high !== null) {
+      sections.push(`- **pLDDT Very High (>90):** ${detail.plddt_very_high.toFixed(1)}%`);
+    }
+    if (detail.plddt_confident !== null) {
+      sections.push(`- **pLDDT Confident (70-90):** ${detail.plddt_confident.toFixed(1)}%`);
+    }
+    if (detail.plddt_low !== null) {
+      sections.push(`- **pLDDT Low (50-70):** ${detail.plddt_low.toFixed(1)}%`);
+    }
+    if (detail.plddt_very_low !== null) {
+      sections.push(`- **pLDDT Very Low (<50):** ${detail.plddt_very_low.toFixed(1)}%`);
+    }
+
+    if (detail.ai_summary) {
+      sections.push(`\n### AI Structural Summary\n${detail.ai_summary}`);
+    }
+
+    if (detail.research_brief) {
+      sections.push(`\n### Research Brief\n${detail.research_brief}`);
+    }
+
+    sections.push("");
+  }
+
+  // Clinical data
+  if (clinicalData) {
+    sections.push(`## Clinical Data\n`);
+
+    if (clinicalData.clinvar) {
+      sections.push(`### ClinVar`);
+      if (clinicalData.clinvar.clinical_significance) {
+        sections.push(`- **Clinical Significance:** ${clinicalData.clinvar.clinical_significance}`);
+      }
+      if (clinicalData.clinvar.review_status) {
+        sections.push(`- **Review Status:** ${clinicalData.clinvar.review_status}`);
+      }
+      if (clinicalData.clinvar.last_evaluated) {
+        sections.push(`- **Last Evaluated:** ${clinicalData.clinvar.last_evaluated}`);
+      }
+      if (clinicalData.clinvar.conditions && clinicalData.clinvar.conditions.length > 0) {
+        sections.push(`- **Conditions:** ${clinicalData.clinvar.conditions.join(", ")}`);
+      }
+    } else {
+      sections.push(`### ClinVar\nNo ClinVar data available.`);
+    }
+
+    if (clinicalData.gnomad) {
+      sections.push(`\n### gnomAD Population Data`);
+      if (clinicalData.gnomad.allele_frequency !== null) {
+        sections.push(`- **Allele Frequency:** ${clinicalData.gnomad.allele_frequency.toExponential(4)}`);
+      }
+      if (clinicalData.gnomad.allele_count !== null) {
+        sections.push(`- **Allele Count:** ${clinicalData.gnomad.allele_count}`);
+      }
+      if (clinicalData.gnomad.allele_number !== null) {
+        sections.push(`- **Allele Number:** ${clinicalData.gnomad.allele_number}`);
+      }
+      if (clinicalData.gnomad.homozygote_count !== null) {
+        sections.push(`- **Homozygote Count:** ${clinicalData.gnomad.homozygote_count}`);
+      }
+    } else {
+      sections.push(`\n### gnomAD\nNo gnomAD data available.`);
+    }
+
+    sections.push("");
+  }
+
+  // Agent findings
+  if (findings.length > 0) {
+    sections.push(`## Agent Research Findings (${findings.length})\n`);
+    for (const finding of findings) {
+      sections.push(`### [${finding.agent_type}] ${finding.title}`);
+      sections.push(finding.content);
+      if (finding.source_url) {
+        sections.push(`Source: ${finding.source_url}`);
+      }
+      sections.push(`_${finding.finding_type} — ${finding.created_at}_\n`);
+    }
+  }
+
+  // Agent annotations
+  if (annotations.length > 0) {
+    sections.push(`## Agent Annotations (${annotations.length})\n`);
+    for (const annotation of annotations) {
+      sections.push(
+        `- **[${annotation.agent_id}]** (${annotation.annotation_type}, confidence: ${annotation.confidence}): ${annotation.content}`,
+      );
+    }
+    sections.push("");
+  }
+
+  if (!detail && !clinicalData && findings.length === 0 && annotations.length === 0) {
+    sections.push(
+      `No detailed data available for ${protein} ${variant} in Clarity Protocol.`,
+    );
+  }
+
+  return sections.join("\n");
+}

--- a/src/agents/clarity/parser.ts
+++ b/src/agents/clarity/parser.ts
@@ -1,0 +1,65 @@
+/**
+ * Extracts protein name and variant notation from natural language objectives.
+ *
+ * Handles patterns like:
+ * - "SOD1 A4V" → { protein: "SOD1", variant: "A4V" }
+ * - "alpha-synuclein A53T" → { protein: "alpha-synuclein", variant: "A53T" }
+ * - "Query fold data for tau P301L" → { protein: "tau", variant: "P301L" }
+ * - "What is the structural impact of APOE C112R?" → { protein: "APOE", variant: "C112R" }
+ */
+
+export type ParsedVariant = {
+  protein: string;
+  variant: string;
+};
+
+// Standard single-residue substitution: letter, digits, letter (e.g. A4V, G2019S, C112R)
+const VARIANT_PATTERN = /[A-Z]\d+[A-Z]/;
+
+// Protein name: word characters plus hyphens (e.g. alpha-synuclein, TDP-43, SOD1)
+const PROTEIN_VARIANT_PATTERN =
+  /\b([\w][\w-]*)\s+([A-Z]\d+[A-Z])\b/;
+
+export function parseVariantFromObjective(
+  objective: string,
+): ParsedVariant | null {
+  // Try the combined protein + variant pattern first
+  const match = objective.match(PROTEIN_VARIANT_PATTERN);
+  if (match && match[1] && match[2]) {
+    const candidate = match[1];
+    // Skip common English words that might precede a variant-like pattern
+    const skipWords = new Set([
+      "the",
+      "for",
+      "and",
+      "with",
+      "from",
+      "about",
+      "into",
+      "like",
+      "over",
+      "position",
+      "residue",
+      "mutation",
+      "variant",
+      "substitution",
+    ]);
+    if (!skipWords.has(candidate.toLowerCase())) {
+      return { protein: candidate, variant: match[2] };
+    }
+  }
+
+  // Fallback: find any variant pattern and take the preceding word as protein
+  const variantMatch = objective.match(VARIANT_PATTERN);
+  if (variantMatch) {
+    const idx = objective.indexOf(variantMatch[0]);
+    const before = objective.slice(0, idx).trim();
+    const words = before.split(/\s+/);
+    const lastWord = words[words.length - 1];
+    if (lastWord && lastWord.length >= 2) {
+      return { protein: lastWord, variant: variantMatch[0] };
+    }
+  }
+
+  return null;
+}

--- a/src/agents/planning/prompts.ts
+++ b/src/agents/planning/prompts.ts
@@ -20,7 +20,7 @@ CURRENT RESEARCH STATE:
 USER'S MESSAGE:
 {userMessage}
 
-AVAILABLE TASK TYPES (only these two):
+AVAILABLE TASK TYPES (only these three):
 - LITERATURE: Search and gather scientific papers and knowledge from literature databases. Use it to:
   - Find recent research
   - Search Specialized Medical Databases (UniProt, PubChem...)
@@ -42,9 +42,13 @@ AVAILABLE TASK TYPES (only these two):
   - "Are the survival differences significant in our treatment groups dataset?" � Statistical analysis of uploaded lifespan/healthspan data
   - "How do aging biomarkers change over time in our longitudinal study?" � Time-series analysis of uploaded longitudinal datasets
 
+
+- CLARITY: Query Clarity Protocol for protein fold predictions (AlphaFold2), structural confidence scores (pLDDT/PAE), clinical variant annotations (ClinVar pathogenicity, gnomAD allele frequency), and AI agent research findings for a specific protein variant. Use when the research involves a known disease-linked protein mutation and you need structural or clinical context. Clarity Protocol covers Alzheimer's (tau, amyloid-beta, APOE, presenilin), Parkinson's (alpha-synuclein, LRRK2, PINK1, Parkin), ALS (SOD1, TDP-43, FUS), and other disease variants.
+
 TASK OBJECTIVE FORMATTING:
 - For LITERATURE tasks: describe the objective simply in 1-2 sentences, focusing on what information to gather
 - For ANALYSIS tasks: Use format "GOAL: <goal> DATASETS: <short dataset descriptions> OUTPUT: <desired output>". Keep each section simple (1-3 sentences). Focus on WHAT, not HOW.
+- For CLARITY tasks: mention the protein name and variant notation (e.g., "Query fold data for SOD1 A4V" or "Get structural and clinical data for tau P301L")
 
 OUTPUT FORMAT (you MUST respond with ONLY valid JSON):
 {
@@ -53,7 +57,7 @@ OUTPUT FORMAT (you MUST respond with ONLY valid JSON):
     {
       "objective": "Specific objective tailored to this task",
       "datasets": [{"filename": "example.csv", "id": "dataset-id", "description": "Brief dataset description"}], // Dataset metadata, only for ANALYSIS tasks
-      "type": "LITERATURE or ANALYSIS"
+      "type": "LITERATURE, ANALYSIS, or CLARITY"
     }
   ]
 }
@@ -65,6 +69,7 @@ NOTES:
 - Tasks will be executed in PARALLEL, so if tasks depend on each other, only plan the first ones
 - Plan only 1-3 tasks maximum
 - For LITERATURE tasks: datasets array should be EMPTY []
+- For CLARITY tasks: datasets array should be EMPTY []. The objective should name the protein and variant.
 - PRESERVING USER'S ORIGINAL PHRASING (for LITERATURE tasks): If the user's message is already a sensible, well-formed query for literature search, use it VERBATIM as the task objective. Do NOT rephrase for the sake of rephrasing—unnecessary rewording degrades search results. Only modify when you have a concrete reason: adding constraints mentioned elsewhere, clarifying genuine ambiguity, or combining multiple requests. When in doubt, preserve the user's exact wording.
 - For ANALYSIS tasks: Only include if datasets are mentioned in the user's message
   - If there's an open source dataset linked in the message, DO NOT put it in the datasets array. Instead use the task objective to let the data scientist agent know that it should download and use the open source dataset.
@@ -137,7 +142,7 @@ CURRENT RESEARCH STATE:
 USER'S LATEST MESSAGE:
 {userMessage}
 
-AVAILABLE TASK TYPES (only these two):
+AVAILABLE TASK TYPES (only these three):
 - LITERATURE: Search and gather scientific papers and knowledge from literature databases. Use it to:
   - Find recent research
   - Search Specialized Medical Databases (UniProt, PubChem...)
@@ -159,9 +164,13 @@ AVAILABLE TASK TYPES (only these two):
   - "Are the survival differences significant in our treatment groups dataset?" � Statistical analysis of uploaded lifespan/healthspan data
   - "How do aging biomarkers change over time in our longitudinal study?" � Time-series analysis of uploaded longitudinal datasets
 
+
+- CLARITY: Query Clarity Protocol for protein fold predictions (AlphaFold2), structural confidence scores (pLDDT/PAE), clinical variant annotations (ClinVar pathogenicity, gnomAD allele frequency), and AI agent research findings for a specific protein variant. Use when the research involves a known disease-linked protein mutation and you need structural or clinical context. Clarity Protocol covers Alzheimer's (tau, amyloid-beta, APOE, presenilin), Parkinson's (alpha-synuclein, LRRK2, PINK1, Parkin), ALS (SOD1, TDP-43, FUS), and other disease variants.
+
 TASK OBJECTIVE FORMATTING:
 - For LITERATURE tasks: describe the objective simply in 1-2 sentences
 - For ANALYSIS tasks: Describe the objective in this format "GOAL: <goal> DATASETS: <short dataset descriptions> OUTPUT: <desired output>". Each section should be relatively simple, 1-3 sentences max. Do not overexplain so that you allow the data scientist agent to be creative and come up with the best solution. Focus on the what, not on the how.
+- For CLARITY tasks: mention the protein name and variant notation (e.g., "Query fold data for SOD1 A4V" or "Get structural and clinical data for tau P301L")
 
 OUTPUT FORMAT (you MUST respond with ONLY valid JSON):
 {
@@ -170,7 +179,7 @@ OUTPUT FORMAT (you MUST respond with ONLY valid JSON):
     {
       "objective": "Specific objective tailored to this task",
       "datasets": [{"filename": "example.csv", "id": "dataset-id", "description": "Brief dataset description"}], // Dataset metadata, only for ANALYSIS tasks. Leave empty for LITERATURE tasks.
-      "type": "LITERATURE or ANALYSIS"
+      "type": "LITERATURE, ANALYSIS, or CLARITY"
     }
   ]
 }
@@ -179,6 +188,7 @@ NOTES:
 - Choose LITERATURE if: You need to find, read, or synthesize information from scientific papers
 - Choose ANALYSIS if: You have datasets that need coding, statistics, visualization, or any computational processing
 - For LITERATURE tasks: datasets array should be EMPTY []
+- For CLARITY tasks: datasets array should be EMPTY []. The objective should name the protein and variant.
 - PRESERVING USER'S ORIGINAL PHRASING (for LITERATURE tasks): If the user's message/feedback is already a sensible, well-formed query for literature search, use it VERBATIM as the task objective. Do NOT rephrase for the sake of rephrasing—unnecessary rewording degrades search results. Only modify when you have a concrete reason: adding constraints mentioned elsewhere, clarifying genuine ambiguity, or combining multiple requests. When in doubt, preserve the user's exact wording.
 - For ANALYSIS tasks: SELECT which uploaded datasets (shown in the CURRENT RESEARCH STATE above) are relevant for the analysis task
   - Only include datasets that are directly relevant to the specific analysis objective
@@ -266,7 +276,7 @@ CURRENT RESEARCH STATE:
 USER'S LATEST MESSAGE:
 {userMessage}
 
-AVAILABLE TASK TYPES (only these two):
+AVAILABLE TASK TYPES (only these three):
 - LITERATURE: Search and gather scientific papers and knowledge from literature databases. Use it to:
   - Find recent research
   - Search Specialized Medical Databases (UniProt, PubChem...)
@@ -288,9 +298,13 @@ AVAILABLE TASK TYPES (only these two):
   - "Are the survival differences significant in our treatment groups dataset?" � Statistical analysis of uploaded lifespan/healthspan data
   - "How do aging biomarkers change over time in our longitudinal study?" � Time-series analysis of uploaded longitudinal datasets
 
+
+- CLARITY: Query Clarity Protocol for protein fold predictions (AlphaFold2), structural confidence scores (pLDDT/PAE), clinical variant annotations (ClinVar pathogenicity, gnomAD allele frequency), and AI agent research findings for a specific protein variant. Use when the research involves a known disease-linked protein mutation and you need structural or clinical context. Clarity Protocol covers Alzheimer's (tau, amyloid-beta, APOE, presenilin), Parkinson's (alpha-synuclein, LRRK2, PINK1, Parkin), ALS (SOD1, TDP-43, FUS), and other disease variants.
+
 TASK OBJECTIVE FORMATTING:
 - For LITERATURE tasks: describe the objective simply in 1-2 sentences
 - For ANALYSIS tasks: Describe the objective in this format "GOAL: <goal> DATASETS: <short dataset descriptions> OUTPUT: <desired output>". Each section should be relatively simple, 1-3 sentences max. Do not overexplain so that you allow the data scientist agent to be creative and come up with the best solution. Focus on the what, not on the how.
+- For CLARITY tasks: mention the protein name and variant notation (e.g., "Query fold data for SOD1 A4V" or "Get structural and clinical data for tau P301L")
 
 OUTPUT FORMAT (you MUST respond with ONLY valid JSON):
 {
@@ -299,7 +313,7 @@ OUTPUT FORMAT (you MUST respond with ONLY valid JSON):
     {
       "objective": "Specific objective tailored to this task",
       "datasets": [{"filename": "example.csv", "id": "dataset-id", "description": "Brief dataset description"}], // Dataset metadata, only for ANALYSIS tasks
-      "type": "LITERATURE or ANALYSIS"
+      "type": "LITERATURE, ANALYSIS, or CLARITY"
     }
   ]
 }
@@ -308,6 +322,7 @@ NOTES:
 - Choose LITERATURE if: You need to find, read, or synthesize information from scientific papers
 - Choose ANALYSIS if: You have datasets that need coding, statistics, visualization, or any computational processing
 - For LITERATURE tasks: datasets array should be EMPTY []
+- For CLARITY tasks: datasets array should be EMPTY []. The objective should name the protein and variant.
 - For ANALYSIS tasks: SELECT which uploaded datasets (shown in the CURRENT RESEARCH STATE above) are relevant for the analysis task
   - Only include datasets that are directly relevant to the specific analysis objective
   - Copy the exact dataset objects (filename, id, description) from the "Uploaded Datasets" section above

--- a/src/types/clarification.ts
+++ b/src/types/clarification.ts
@@ -47,7 +47,7 @@ export interface ClarificationAnswer {
  */
 export interface ClarificationPlanTask {
   objective: string;
-  type: "LITERATURE" | "ANALYSIS";
+  type: "LITERATURE" | "ANALYSIS" | "CLARITY";
   datasetFilenames: string[]; // Filenames to match against uploadedDatasets at execution time
 }
 

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -41,7 +41,7 @@ export type PlanTask = {
     description: string;
     path?: string;
   }>;
-  type: "LITERATURE" | "ANALYSIS";
+  type: "LITERATURE" | "ANALYSIS" | "CLARITY";
   level?: number;
   start?: string;
   end?: string;
@@ -100,7 +100,7 @@ export interface ConversationStateValues extends StateValues {
     }>;
     initialTasks?: Array<{
       objective: string;
-      type: "LITERATURE" | "ANALYSIS";
+      type: "LITERATURE" | "ANALYSIS" | "CLARITY";
       datasetFilenames: string[]; // Filenames to match against uploadedDatasets
     }>; // Tasks for first iteration (used once, then cleared)
   };

--- a/src/utils/planningJsonExtractor.ts
+++ b/src/utils/planningJsonExtractor.ts
@@ -106,11 +106,11 @@ function extractFieldsWithRegex(content: string): PlanningResult {
 
   // Extract plan tasks - look for LITERATURE or ANALYSIS task patterns
   const taskPattern =
-    /"type"\s*:\s*"(LITERATURE|ANALYSIS)"[\s\S]*?"objective"\s*:\s*"([^"\\]*(?:\\.[^"\\]*)*)"/g;
+    /"type"\s*:\s*"(LITERATURE|ANALYSIS|CLARITY)"[\s\S]*?"objective"\s*:\s*"([^"\\]*(?:\\.[^"\\]*)*)"/g;
   let match;
   while ((match = taskPattern.exec(content)) !== null) {
     const task: PlanTask = {
-      type: match[1] as "LITERATURE" | "ANALYSIS",
+      type: match[1] as "LITERATURE" | "ANALYSIS" | "CLARITY",
       objective: match[2]?.replace(/\\"/g, '"') || "",
       datasets: [],
       level: result.plan.length + 1,


### PR DESCRIPTION
## Summary

- Adds a third task type (`CLARITY`) to BioAgents deep research, enabling BIOS to query Clarity Protocol for protein fold predictions, clinical annotations, and AI agent findings when researching disease-linked protein variants
- New agent at `src/agents/clarity/` with API client, variant parser, and orchestrator
- Integrated into planning prompts, deep research execution (both in-process and queue modes), and clarification agent
- 12 files changed, 754 insertions

## What it does

When BIOS researches a protein variant (e.g., SOD1 A4V, tau P301L), the planning agent can now generate CLARITY tasks alongside LITERATURE and ANALYSIS tasks. The clarity agent:

1. Parses protein name + variant from the research objective
2. Searches Clarity Protocol for matching fold data
3. Fetches variant detail (pLDDT scores, AI summary, research brief)
4. Fetches agent findings and annotations from Clarity's 4 research agents
5. Fetches clinical data (ClinVar + gnomAD)
6. Returns structured markdown output for the research pipeline

## Config

```bash
CLARITY_API_URL=https://clarityprotocol.io/api/v1
CLARITY_API_KEY=  # Optional, for higher rate limits
```

## Test plan

- [ ] Run deep research with a protein variant query (e.g., 'What is known about SOD1 A4V?')
- [ ] Verify CLARITY tasks appear in planning output
- [ ] Verify clarity agent returns fold data, findings, and clinical data
- [ ] Verify graceful fallback when variant not found in Clarity