### PR TITLE
Migrate Anthropic models from Claude 4.5 to 4.6

### DIFF
--- a/src/agents/continueResearch/utils.ts
+++ b/src/agents/continueResearch/utils.ts
@@ -51,7 +51,7 @@ export async function decideContinuation(
   options: ContinueResearchOptions = {},
 ): Promise<ContinueResearchDecision> {
   const model =
-    process.env.CONTINUE_RESEARCH_LLM_MODEL || "claude-sonnet-4-5-20250929";
+    process.env.CONTINUE_RESEARCH_LLM_MODEL || "claude-sonnet-4-6";
 
   // Build document content (all task outputs)
   const allTaskOutputs = documents

--- a/src/agents/hypothesis/utils.ts
+++ b/src/agents/hypothesis/utils.ts
@@ -71,12 +71,8 @@ export async function generateHypothesis(
     model,
     messages: [
       {
-        role: "assistant" as const,
-        content: `Use the following evidence set to formulate a hypothesis: ${documentText}`,
-      },
-      {
         role: "user" as const,
-        content: hypGenInstruction,
+        content: `Use the following evidence set to formulate a hypothesis:\n\n${documentText}\n\n---\n\n${hypGenInstruction}`,
       },
     ],
     maxTokens: options.maxTokens ?? 4000,

--- a/src/llm/adapters/anthropic.ts
+++ b/src/llm/adapters/anthropic.ts
@@ -260,12 +260,17 @@ export class AnthropicAdapter extends LLMAdapter {
         }
       });
 
-    // Anthropic requires max_tokens > thinking.budget_tokens
-    // We handle this by adding thinkingBudget to maxTokens so developers can think of them as separate budgets
+    // Detect Opus 4.6 models which require adaptive thinking (budget_tokens is deprecated)
+    const isOpus46 = request.model.includes("opus-4-6");
+    const useAdaptiveThinking = isOpus46 && request.thinkingBudget !== undefined;
+
+    // For adaptive thinking (Opus 4.6), no need to inflate max_tokens with thinking budget
+    // For budget_tokens mode (Sonnet 4.6 and older), max_tokens must be > budget_tokens
     const baseMaxTokens = request.maxTokens ?? 5000;
-    const effectiveMaxTokens = request.thinkingBudget
-      ? baseMaxTokens + request.thinkingBudget
-      : baseMaxTokens;
+    const effectiveMaxTokens =
+      request.thinkingBudget && !useAdaptiveThinking
+        ? baseMaxTokens + request.thinkingBudget
+        : baseMaxTokens;
 
     const anthropicRequest: MessageCreateParamsNonStreaming = {
       model: request.model,
@@ -286,7 +291,13 @@ export class AnthropicAdapter extends LLMAdapter {
       anthropicRequest.temperature = 1;
     }
 
-    if (request.thinkingBudget !== undefined) {
+    if (useAdaptiveThinking) {
+      // Opus 4.6: Use adaptive thinking with effort parameter (GA, no beta needed)
+      (anthropicRequest as any).thinking = { type: "adaptive" };
+      const effort = request.effort ?? this.mapThinkingBudgetToEffort(request.thinkingBudget!);
+      (anthropicRequest as any).output_config = { effort };
+    } else if (request.thinkingBudget !== undefined) {
+      // Sonnet 4.6 and older models: Use budget_tokens (still supported)
       anthropicRequest.thinking = {
         type: "enabled",
         budget_tokens: request.thinkingBudget,
@@ -461,6 +472,16 @@ export class AnthropicAdapter extends LLMAdapter {
     });
 
     return Array.from(deduped.values());
+  }
+
+  /**
+   * Maps thinkingBudget (token count) to Anthropic effort level for adaptive thinking.
+   * Used for Opus 4.6+ where budget_tokens is deprecated.
+   */
+  private mapThinkingBudgetToEffort(thinkingBudget: number): "low" | "medium" | "high" {
+    if (thinkingBudget <= 1024) return "low";
+    if (thinkingBudget <= 4096) return "medium";
+    return "high";
   }
 
   private normalizeUrl(url: string): string {

--- a/src/llm/adapters/anthropic.ts
+++ b/src/llm/adapters/anthropic.ts
@@ -22,6 +22,11 @@ interface BuildRequestOptions {
   includeWebSearch?: boolean;
 }
 
+interface AnthropicAdaptiveThinkingExtension {
+  thinking: { type: "adaptive" };
+  output_config: { effort: "low" | "medium" | "high" };
+}
+
 export class AnthropicAdapter extends LLMAdapter {
   private client: Anthropic;
 
@@ -293,11 +298,12 @@ export class AnthropicAdapter extends LLMAdapter {
 
     if (useAdaptiveThinking) {
       // Opus 4.6: Use adaptive thinking with effort parameter (GA, no beta needed)
-      (anthropicRequest as any).thinking = { type: "adaptive" };
       const effort = request.effort ?? (request.thinkingBudget !== undefined
         ? this.mapThinkingBudgetToEffort(request.thinkingBudget)
         : "medium");
-      (anthropicRequest as any).output_config = { effort };
+      const adaptiveRequest = anthropicRequest as MessageCreateParamsNonStreaming & AnthropicAdaptiveThinkingExtension;
+      adaptiveRequest.thinking = { type: "adaptive" };
+      adaptiveRequest.output_config = { effort };
     } else if (request.thinkingBudget !== undefined) {
       // Sonnet 4.6 and older models: Use budget_tokens (still supported)
       anthropicRequest.thinking = {

--- a/src/llm/adapters/anthropic.ts
+++ b/src/llm/adapters/anthropic.ts
@@ -262,7 +262,7 @@ export class AnthropicAdapter extends LLMAdapter {
 
     // Detect Opus 4.6 models which require adaptive thinking (budget_tokens is deprecated)
     const isOpus46 = request.model.includes("opus-4-6");
-    const useAdaptiveThinking = isOpus46 && request.thinkingBudget !== undefined;
+    const useAdaptiveThinking = isOpus46 && (request.thinkingBudget !== undefined || request.effort !== undefined);
 
     // For adaptive thinking (Opus 4.6), no need to inflate max_tokens with thinking budget
     // For budget_tokens mode (Sonnet 4.6 and older), max_tokens must be > budget_tokens
@@ -294,7 +294,9 @@ export class AnthropicAdapter extends LLMAdapter {
     if (useAdaptiveThinking) {
       // Opus 4.6: Use adaptive thinking with effort parameter (GA, no beta needed)
       (anthropicRequest as any).thinking = { type: "adaptive" };
-      const effort = request.effort ?? this.mapThinkingBudgetToEffort(request.thinkingBudget!);
+      const effort = request.effort ?? (request.thinkingBudget !== undefined
+        ? this.mapThinkingBudgetToEffort(request.thinkingBudget)
+        : "medium");
       (anthropicRequest as any).output_config = { effort };
     } else if (request.thinkingBudget !== undefined) {
       // Sonnet 4.6 and older models: Use budget_tokens (still supported)

--- a/src/llm/retry.ts
+++ b/src/llm/retry.ts
@@ -23,7 +23,7 @@ export const FALLBACK_CONFIG: Record<
   { provider: string; model: string }
 > = {
   anthropic: { provider: "google", model: "gemini-2.5-pro" },
-  google: { provider: "anthropic", model: "claude-sonnet-4-5-20250514" },
+  google: { provider: "anthropic", model: "claude-sonnet-4-6" },
   openai: { provider: "google", model: "gemini-2.5-pro" },
   openrouter: { provider: "google", model: "gemini-2.5-pro" },
 };

--- a/src/llm/test/test-all-adapters.ts
+++ b/src/llm/test/test-all-adapters.ts
@@ -156,8 +156,8 @@ async function run(): Promise<void> {
         displayName: 'Anthropic',
         apiKey: anthropicKey,
         baseUrl: process.env.ANTHROPIC_BASE_URL,
-        chatModel: process.env.ANTHROPIC_CHAT_MODEL ?? 'claude-sonnet-4-5-20250929',
-        webSearchModel: process.env.ANTHROPIC_WEB_SEARCH_MODEL ?? 'claude-opus-4-1-20250805',
+        chatModel: process.env.ANTHROPIC_CHAT_MODEL ?? 'claude-sonnet-4-6',
+        webSearchModel: process.env.ANTHROPIC_WEB_SEARCH_MODEL ?? 'claude-opus-4-6',
         chatRequest: {
           systemInstruction:
             'You are an insightful assistant. Provide thoughtful but concise answers.',

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -16,6 +16,7 @@ export interface LLMRequest {
   systemInstruction?: string;
   tools?: LLMTool[];
   thinkingBudget?: number;
+  effort?: 'low' | 'medium' | 'high'; // Anthropic Claude 4.6+ adaptive thinking effort level
   maxTokens?: number;
   temperature?: number;
   reasoningEffort?: 'low' | 'medium' | 'high';


### PR DESCRIPTION
## Summary

- Fix breaking assistant prefill in hypothesis agent (400 error on 4.6)
- Use adaptive thinking + effort for Opus 4.6 (budget_tokens deprecated)
- Update fallback model IDs to claude-sonnet-4-6 and claude-opus-4-6

## .env changes needed after merge

```
PLANNING_LLM_MODEL=claude-opus-4-6
REPLY_LLM_MODEL=claude-sonnet-4-6
HYP_LLM_MODEL=claude-sonnet-4-6
CONTINUE_RESEARCH_LLM_MODEL=claude-sonnet-4-6
```

## Test plan

- [ ] Verify planning agent works with Opus 4.6 (adaptive thinking)
- [ ] Verify hypothesis generation works without prefill
- [ ] Verify reply/continue-research agents work with Sonnet 4.6