### PR TITLE
Updated default chat agent model to claude-sonnet-4-6

### DIFF
--- a/src/chat-agent/runner.ts
+++ b/src/chat-agent/runner.ts
@@ -70,7 +70,7 @@ export async function runChatAgent(
   }
 
   const model =
-    process.env.CHAT_AGENT_MODEL || "claude-sonnet-4-20250514";
+    process.env.CHAT_AGENT_MODEL || "claude-sonnet-4-6";
   const maxToolCalls =
     parseInt(process.env.CHAT_AGENT_MAX_TOOL_CALLS || "") || 10;
   const maxTokens =


### PR DESCRIPTION
Follow-up to #148. Ritvik pointed out that `claude-sonnet-4-20250514` is Sonnet 4 (older) — updated default to `claude-sonnet-4-6` (Sonnet 4.6, newer). The alias also always tracks the latest Sonnet 4.x release.