### PR TITLE
Updated models to gpt-5.4 and fixed reasoning_effort parameter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,16 +33,16 @@ PRIMARY_LITERATURE_AGENT=
 BIO_LIT_AGENT_API_URL=
 BIO_LIT_AGENT_API_KEY=
 REPLY_LLM_PROVIDER=openai
-REPLY_LLM_MODEL=gpt-5
+REPLY_LLM_MODEL=gpt-5.4
 
 HYP_LLM_PROVIDER=openai
-HYP_LLM_MODEL=gpt-5
+HYP_LLM_MODEL=gpt-5.4
 
 PLANNING_LLM_PROVIDER=openai
-PLANNING_LLM_MODEL=gpt-5
+PLANNING_LLM_MODEL=gpt-5.4
 
 STRUCTURED_LLM_PROVIDER=openai
-STRUCTURED_LLM_MODEL=gpt-5
+STRUCTURED_LLM_MODEL=gpt-5.4
 
 
 GOOGLE_API_KEY=
@@ -50,6 +50,8 @@ ANTHROPIC_API_KEY=
 OPENROUTER_API_KEY=
 
 # Chat Agent Loop (shared config for in-process and queue mode)
+# Note: chat mode currently uses the Anthropic SDK directly, so this model is
+# not provider-agnostic like the deep-research agents above.
 CHAT_AGENT_MODEL=claude-sonnet-4-6
 CHAT_AGENT_MAX_TOOL_CALLS=10
 CHAT_AGENT_MAX_TOKENS=4096

--- a/.env.worker.example
+++ b/.env.worker.example
@@ -33,17 +33,17 @@ OPENROUTER_API_KEY=
 # OPTIONAL: Agent Configuration
 # --------------------------------------------------------------------------
 # LLM providers: openai, google, anthropic, openrouter
-REPLY_LLM_PROVIDER=google
-REPLY_LLM_MODEL=gemini-2.5-pro
+REPLY_LLM_PROVIDER=openai
+REPLY_LLM_MODEL=gpt-5.4
 
-HYP_LLM_PROVIDER=google
-HYP_LLM_MODEL=gemini-2.5-pro
+HYP_LLM_PROVIDER=openai
+HYP_LLM_MODEL=gpt-5.4
 
-PLANNING_LLM_PROVIDER=google
-PLANNING_LLM_MODEL=gemini-2.5-flash
+PLANNING_LLM_PROVIDER=openai
+PLANNING_LLM_MODEL=gpt-5.4
 
-STRUCTURED_LLM_PROVIDER=google
-STRUCTURED_LLM_MODEL=gemini-2.5-flash
+STRUCTURED_LLM_PROVIDER=openai
+STRUCTURED_LLM_MODEL=gpt-5.4
 
 # --------------------------------------------------------------------------
 # OPTIONAL: Literature & Analysis Services

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ AI-powered research assistant for bioscience literature and data analysis.
 
 ## Related Documentation
 
+- [ARCHITECTURE_OVERVIEW.md](documentation/docs/ARCHITECTURE_OVERVIEW.md) - **Complete system architecture reference**
+- [FLOWS.md](documentation/docs/FLOWS.md) - **End-to-end code flow traces** (every step → file:line)
 - [AUTH.md](documentation/docs/AUTH.md) - Authentication (JWT, x402/b402 payments)
 - [SETUP.md](documentation/docs/SETUP.md) - Environment setup and LLM configuration
 - [JOB_QUEUE.md](documentation/docs/JOB_QUEUE.md) - BullMQ queue system architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,6 @@ AI-powered research assistant for bioscience literature and data analysis.
 
 ## Related Documentation
 
-- [ARCHITECTURE_OVERVIEW.md](documentation/docs/ARCHITECTURE_OVERVIEW.md) - **Complete system architecture reference**
-- [FLOWS.md](documentation/docs/FLOWS.md) - **End-to-end code flow traces** (every step → file:line)
 - [AUTH.md](documentation/docs/AUTH.md) - Authentication (JWT, x402/b402 payments)
 - [SETUP.md](documentation/docs/SETUP.md) - Environment setup and LLM configuration
 - [JOB_QUEUE.md](documentation/docs/JOB_QUEUE.md) - BullMQ queue system architecture

--- a/documentation/content/getting-started/configuration.md
+++ b/documentation/content/getting-started/configuration.md
@@ -36,20 +36,24 @@ Configure which models to use for different agents:
 ```bash
 # Reply generation
 REPLY_LLM_PROVIDER=openai
-REPLY_LLM_MODEL=gpt-4
+REPLY_LLM_MODEL=gpt-5.4
 
 # Hypothesis generation
 HYP_LLM_PROVIDER=openai
-HYP_LLM_MODEL=gpt-4
+HYP_LLM_MODEL=gpt-5.4
 
 # Planning
 PLANNING_LLM_PROVIDER=openai
-PLANNING_LLM_MODEL=gpt-4
+PLANNING_LLM_MODEL=gpt-5.4
 
 # Structured output
 STRUCTURED_LLM_PROVIDER=openai
-STRUCTURED_LLM_MODEL=gpt-4
+STRUCTURED_LLM_MODEL=gpt-5.4
 ```
+
+Deep Research agent selection is provider/model env-driven. The separate `/api/chat`
+agent loop currently uses the Anthropic SDK directly via `CHAT_AGENT_MODEL`, so moving
+that path to OpenAI requires code changes in addition to env changes.
 
 ## Embedding Configuration
 

--- a/documentation/docs/SETUP.md
+++ b/documentation/docs/SETUP.md
@@ -30,16 +30,16 @@ Configure which LLM provider to use for each agent:
 ```bash
 # Choose provider for each agent
 REPLY_LLM_PROVIDER=openai          # or google, anthropic, openrouter
-REPLY_LLM_MODEL=gpt-4o
+REPLY_LLM_MODEL=gpt-5.4
 
 HYP_LLM_PROVIDER=openai
-HYP_LLM_MODEL=gpt-4o
+HYP_LLM_MODEL=gpt-5.4
 
 PLANNING_LLM_PROVIDER=openai
-PLANNING_LLM_MODEL=gpt-4o
+PLANNING_LLM_MODEL=gpt-5.4
 
 STRUCTURED_LLM_PROVIDER=openai
-STRUCTURED_LLM_MODEL=gpt-4o
+STRUCTURED_LLM_MODEL=gpt-5.4
 
 # Add API keys for your chosen providers
 OPENAI_API_KEY=sk-...
@@ -47,6 +47,10 @@ GOOGLE_API_KEY=...              # If using Google
 ANTHROPIC_API_KEY=...           # If using Anthropic
 OPENROUTER_API_KEY=...          # If using OpenRouter
 ```
+
+Deep Research agent selection is provider/model env-driven. The separate `/api/chat`
+agent loop currently uses the Anthropic SDK directly via `CHAT_AGENT_MODEL`, so moving
+that path to OpenAI requires code changes in addition to env changes.
 
 **Database:**
 

--- a/src/llm/adapters/openai.ts
+++ b/src/llm/adapters/openai.ts
@@ -238,10 +238,10 @@ export class OpenAIAdapter extends LLMAdapter {
       openaiRequest.temperature = request.temperature;
     }
 
-    // Map thinkingBudget to reasoning effort for GPT-5.2+ and o-series models
+    // Map thinkingBudget to Chat Completions reasoning_effort for GPT-5 family models.
     const reasoningEffort = this.mapThinkingBudgetToReasoningEffort(request.thinkingBudget);
     if (reasoningEffort) {
-      (openaiRequest as any).reasoning = { effort: reasoningEffort };
+      (openaiRequest as any).reasoning_effort = reasoningEffort;
     }
 
     const mappedTools = this.mapToolsForChat(request.tools);

--- a/src/llm/test/test-all-adapters.ts
+++ b/src/llm/test/test-all-adapters.ts
@@ -116,8 +116,8 @@ async function run(): Promise<void> {
         displayName: 'OpenAI',
         apiKey: openaiKey,
         baseUrl: process.env.OPENAI_BASE_URL,
-        chatModel: process.env.OPENAI_CHAT_MODEL ?? 'gpt-4o-mini',
-        webSearchModel: process.env.OPENAI_WEB_SEARCH_MODEL ?? 'gpt-5',
+        chatModel: process.env.OPENAI_CHAT_MODEL ?? 'gpt-5.4',
+        webSearchModel: process.env.OPENAI_WEB_SEARCH_MODEL ?? 'gpt-5.4',
         chatRequest: {
           systemInstruction:
             'You are a concise assistant that replies in one sentence, ending each sentence with "hahaha".',


### PR DESCRIPTION
## Summary
- Fixed OpenAI adapter: `reasoning_effort` was incorrectly set as nested `reasoning: { effort }` (Responses API format) instead of top-level `reasoning_effort` (Chat Completions API format)
- Updated all Deep Research agent model defaults to `gpt-5.4` in `.env.example` and `.env.worker.example`
- Updated `SETUP.md` and `configuration.md` docs to reflect `gpt-5.4`
- Added clarifying note that `/api/chat` agent loop uses Anthropic SDK directly via `CHAT_AGENT_MODEL` — not provider-agnostic like Deep Research agents

## Test plan
- [ ] Verify Deep Research agents work end-to-end on staging with gpt-5.4
- [ ] Confirm `reasoning_effort` is correctly passed in requests