### PR TITLE
Added inline citation format to chat agent prompt

### DIFF
--- a/src/chat-agent/runner.ts
+++ b/src/chat-agent/runner.ts
@@ -48,6 +48,7 @@ TOOL USE
 - Do not cite specific papers, DOIs, URLs, journals, or publication details unless they came from a tool result or were explicitly provided in the conversation or uploaded materials.
 - If answering from general knowledge without supporting sources, do not invent or imply citations.
 - When using citations from tool results or user-provided materials, include only the most relevant ones for key claims.
+- Format citations inline as [cited text]{url} where url is a full URL (https://...) or DOI URL (https://doi.org/...). Example: [weight loss of 24%]{https://doi.org/10.1056/NEJMoa2301972}. Do not use markdown link syntax for citations.
 - If a tool fails, briefly explain the limitation and try another approach only if it would materially help.
 - If the request requires capabilities not available in chat mode (for example deep multi-step research, dataset analysis, or code-based analysis), do not imply that you performed them. Give the best concise answer you can with the available tools, and note when Deep Research is better suited for a deeper investigation.
 

--- a/src/chat-agent/runner.ts
+++ b/src/chat-agent/runner.ts
@@ -48,7 +48,7 @@ TOOL USE
 - Do not cite specific papers, DOIs, URLs, journals, or publication details unless they came from a tool result or were explicitly provided in the conversation or uploaded materials.
 - If answering from general knowledge without supporting sources, do not invent or imply citations.
 - When using citations from tool results or user-provided materials, include only the most relevant ones for key claims.
-- Format citations inline as [cited text]{url} where url is a full URL (https://...) or DOI URL (https://doi.org/...). Example: [weight loss of 24%]{https://doi.org/10.1056/NEJMoa2301972}. Do not use markdown link syntax for citations.
+- Format citations inline as [cited text]{url} where url is a full URL (https://...) or DOI URL (https://doi.org/...). Example: [weight loss of 24%]{https://doi.org/10.1056/NEJMoa2301972}. Multiple URLs for the same claim can be comma-separated: [weight loss of 24%]{https://doi.org/10.1056/NEJMoa2301972,https://pubmed.ncbi.nlm.nih.gov/12345678}. Do not use markdown link syntax for citations.
 - If a tool fails, briefly explain the limitation and try another approach only if it would materially help.
 - If the request requires capabilities not available in chat mode (for example deep multi-step research, dataset analysis, or code-based analysis), do not imply that you performed them. Give the best concise answer you can with the available tools, and note when Deep Research is better suited for a deeper investigation.
 


### PR DESCRIPTION
## Summary
- Added `[cited text]{url}` citation format instruction to the chat agent system prompt
- The frontend's `parseCitations.ts` expects this format to render clickable [1][2] citation badges with hover preview cards
- Without this, the LLM was returning citations as plain text and the citation UI was not rendering

## Testing
- Tested locally in queue mode with multiple research queries ("fetch latest papers on longevity", "mRNA vaccine delivery mechanisms")
- Citations render as clickable [1][2] badges with hover cards showing domain, title, and preview
- Links verified against real PMC/PubMed papers
- Simple queries (e.g. "what is DNA") correctly skip tool calls and have no citations