### PR TITLE
Added token streaming for chat agent via WebSocket

### DIFF
--- a/src/chat-agent/loop.ts
+++ b/src/chat-agent/loop.ts
@@ -61,7 +61,19 @@ export async function runAgentLoop(
       tool_choice: !isAtCap && toolDefs.length > 0 ? { type: "auto" as const } : undefined,
     };
 
-    const response = await client.messages.create(requestParams);
+    let response: Anthropic.Message;
+
+    if (config.onTextDelta) {
+      // Streaming path: tokens delivered via callback as they arrive
+      const stream = client.messages.stream(requestParams);
+      stream.on("text", (text) => {
+        config.onTextDelta!(text);
+      });
+      response = await stream.finalMessage();
+    } else {
+      // Non-streaming path: unchanged behavior for callers without callback
+      response = await client.messages.create(requestParams);
+    }
 
     // Track token usage
     if (response.usage) {
@@ -92,6 +104,15 @@ export async function runAgentLoop(
         .map((block) => block.text)
         .join("\n\n");
       break;
+    }
+
+    // Notify caller that streaming is pausing for tool execution
+    if (config.onStreamPause) {
+      try {
+        await config.onStreamPause();
+      } catch (err) {
+        logger.warn({ error: err }, "on_stream_pause_callback_failed");
+      }
     }
 
     // stop_reason === "tool_use" — execute tools

--- a/src/chat-agent/runner.ts
+++ b/src/chat-agent/runner.ts
@@ -25,6 +25,10 @@ export interface RunChatAgentParams {
   loadHistory?: boolean;
   /** Called after each tool execution. Callers customise for DB updates, notifications, etc. */
   onToolResult?: (info: ToolCallInfo) => Promise<void>;
+  /** Called on each text chunk during streaming. Synchronous to avoid backpressure. */
+  onTextDelta?: (delta: string) => void;
+  /** Called after LLM response with tool_use blocks, BEFORE tools execute. */
+  onStreamPause?: () => Promise<void>;
 }
 
 export interface RunChatAgentResult {
@@ -177,6 +181,8 @@ export async function runChatAgent(
       maxTokens,
       apiKey,
       onToolResult: params.onToolResult,
+      onTextDelta: params.onTextDelta,
+      onStreamPause: params.onStreamPause,
     },
     conversationHistory.length > 0 ? conversationHistory : undefined,
   );

--- a/src/chat-agent/types.ts
+++ b/src/chat-agent/types.ts
@@ -44,6 +44,10 @@ export interface AgentLoopConfig {
   apiKey: string;
   /** Called after each tool execution. Use for DB state updates, progress notifications, etc. */
   onToolResult?: (info: ToolCallInfo) => Promise<void>;
+  /** Called on each text chunk during streaming. Synchronous to avoid backpressure on the Anthropic stream. */
+  onTextDelta?: (delta: string) => void;
+  /** Called after LLM response with tool_use blocks, BEFORE tools execute. Use to flush stream buffer and notify frontend. */
+  onStreamPause?: () => Promise<void>;
 }
 
 /**

--- a/src/services/queue/notify.ts
+++ b/src/services/queue/notify.ts
@@ -316,7 +316,7 @@ export async function notifyStreamEnd(
   messageId: string,
   isFinal: boolean,
   turnIndex: number,
-  reason?: "paused" | "truncated" | "complete",
+  reason?: "paused" | "truncated" | "error" | "complete",
 ): Promise<void> {
   await notify({
     type: "message:stream_end",

--- a/src/services/queue/notify.ts
+++ b/src/services/queue/notify.ts
@@ -21,25 +21,36 @@ import logger from "../../utils/logger";
  * Note: This function catches errors internally to avoid crashing workers
  * if Redis is temporarily unavailable. Notifications are best-effort.
  */
-export async function notify(notification: Notification): Promise<void> {
+export async function notify(
+  notification: Notification,
+  options?: { quiet?: boolean },
+): Promise<void> {
   try {
     const publisher = getPublisher();
     const channel = `conversation:${notification.conversationId}`;
 
     await publisher.publish(channel, JSON.stringify(notification));
 
-    logger.info(
-      {
-        type: notification.type,
-        jobId: notification.jobId,
-        conversationId: notification.conversationId,
-        channel,
-      },
-      "notification_published",
-    );
+    if (options?.quiet) {
+      logger.debug(
+        { type: notification.type, conversationId: notification.conversationId },
+        "notification_published",
+      );
+    } else {
+      logger.info(
+        {
+          type: notification.type,
+          jobId: notification.jobId,
+          conversationId: notification.conversationId,
+          channel,
+        },
+        "notification_published",
+      );
+    }
   } catch (error) {
     // Log but don't throw - notification failure shouldn't fail the job
-    logger.error(
+    const logFn = options?.quiet ? logger.warn : logger.error;
+    logFn.call(logger,
       {
         err: error,
         notification,
@@ -258,6 +269,61 @@ export async function notifyPaperFailed(
     conversationId,
     paperId,
     error,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Streaming notification helpers
+// ---------------------------------------------------------------------------
+
+export async function notifyStreamStart(
+  jobId: string,
+  conversationId: string,
+  messageId: string,
+  turnIndex: number,
+): Promise<void> {
+  await notify({
+    type: "message:stream_start",
+    jobId,
+    conversationId,
+    messageId,
+    turnIndex,
+  });
+}
+
+export async function notifyStreamDelta(
+  jobId: string,
+  conversationId: string,
+  messageId: string,
+  delta: string,
+  turnIndex: number,
+): Promise<void> {
+  await notify({
+    type: "message:delta",
+    jobId,
+    conversationId,
+    messageId,
+    delta,
+    turnIndex,
+  }, { quiet: true });
+}
+
+export async function notifyStreamEnd(
+  jobId: string,
+  conversationId: string,
+  messageId: string,
+  isFinal: boolean,
+  turnIndex: number,
+  reason?: "paused" | "truncated" | "complete",
+): Promise<void> {
+  await notify({
+    type: "message:stream_end",
+    jobId,
+    conversationId,
+    messageId,
+    isFinal,
+    turnIndex,
+    reason,
   });
 }
 

--- a/src/services/queue/notify.ts
+++ b/src/services/queue/notify.ts
@@ -50,10 +50,12 @@ export async function notify(
   } catch (error) {
     // Log but don't throw - notification failure shouldn't fail the job
     const logFn = options?.quiet ? logger.warn : logger.error;
+    // Strip delta from error logs to avoid leaking assistant content
+    const { delta: _delta, ...safeNotification } = notification;
     logFn.call(logger,
       {
         err: error,
-        notification,
+        notification: safeNotification,
       },
       "notification_publish_failed",
     );

--- a/src/services/queue/types.ts
+++ b/src/services/queue/types.ts
@@ -195,5 +195,5 @@ export interface Notification {
   delta?: string;
   isFinal?: boolean;
   turnIndex?: number;
-  reason?: "paused" | "truncated" | "complete";
+  reason?: "paused" | "truncated" | "error" | "complete";
 }

--- a/src/services/queue/types.ts
+++ b/src/services/queue/types.ts
@@ -166,6 +166,9 @@ export type NotificationType =
   | "job:completed"
   | "job:failed"
   | "message:updated"
+  | "message:stream_start"
+  | "message:delta"
+  | "message:stream_end"
   | "state:updated"
   | "file:ready"
   | "file:error"
@@ -189,4 +192,8 @@ export interface Notification {
   progress?: { stage: string; percent: number };
   description?: string;
   error?: string;
+  delta?: string;
+  isFinal?: boolean;
+  turnIndex?: number;
+  reason?: "paused" | "truncated" | "complete";
 }

--- a/src/services/queue/workers/chat.worker.ts
+++ b/src/services/queue/workers/chat.worker.ts
@@ -460,6 +460,7 @@ async function processChatJob(
 class StreamBuffer {
   private buffer = "";
   private timer: ReturnType<typeof setTimeout> | null = null;
+  private activeFlush: Promise<void> | null = null;
   private readonly flushFn: (text: string) => Promise<void>;
   private readonly intervalMs: number;
 
@@ -482,18 +483,28 @@ class StreamBuffer {
       clearTimeout(this.timer);
       this.timer = null;
     }
+    // Wait for any in-flight flush to complete before starting a new one
+    if (this.activeFlush) {
+      await this.activeFlush;
+    }
     if (this.buffer.length > 0) {
       const text = this.buffer;
       this.buffer = "";
-      await this.flushFn(text);
+      this.activeFlush = this.flushFn(text);
+      await this.activeFlush;
+      this.activeFlush = null;
     }
   }
 
-  /** Cancel any pending flush and discard buffered text. Use on error to prevent stale delta leaks. */
-  cancel(): void {
+  /** Cancel pending timer and wait for any in-flight flush to complete before discarding. */
+  async cancel(): Promise<void> {
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = null;
+    }
+    if (this.activeFlush) {
+      await this.activeFlush;
+      this.activeFlush = null;
     }
     this.buffer = "";
   }
@@ -605,7 +616,7 @@ async function processWithAgentLoop(
     });
   } catch (err) {
     // Cancel pending buffer to prevent stale deltas leaking into retry attempts
-    streamBuffer.cancel();
+    await streamBuffer.cancel();
     throw err;
   }
 
@@ -616,7 +627,7 @@ async function processWithAgentLoop(
       await streamBuffer.flush();
       await notifyStreamEnd(job.id!, conversationId, messageId, false, turnIndex, "truncated");
     } else {
-      streamBuffer.cancel();
+      await streamBuffer.cancel();
     }
     const { UnrecoverableError } = await import("bullmq");
     throw new UnrecoverableError(
@@ -625,7 +636,7 @@ async function processWithAgentLoop(
   }
 
   if (!result.replyText) {
-    streamBuffer.cancel();
+    await streamBuffer.cancel();
     const { UnrecoverableError } = await import("bullmq");
     throw new UnrecoverableError(
       "Agent loop produced empty reply",

--- a/src/services/queue/workers/chat.worker.ts
+++ b/src/services/queue/workers/chat.worker.ts
@@ -17,6 +17,9 @@ import {
   notifyJobStarted,
   notifyMessageUpdated,
   notifyStateUpdated,
+  notifyStreamStart,
+  notifyStreamDelta,
+  notifyStreamEnd,
 } from "../notify";
 import type { ChatJobData, ChatJobResult, JobProgress } from "../types";
 
@@ -450,8 +453,56 @@ async function processChatJob(
 }
 
 /**
+ * Micro-batching buffer for streaming token deltas.
+ * Accumulates text chunks and flushes every intervalMs via setTimeout.
+ * Reduces Redis pub/sub volume by ~10x while maintaining sub-100ms perceived latency.
+ */
+class StreamBuffer {
+  private buffer = "";
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private readonly flushFn: (text: string) => Promise<void>;
+  private readonly intervalMs: number;
+
+  constructor(flushFn: (text: string) => Promise<void>, intervalMs = 50) {
+    this.flushFn = flushFn;
+    this.intervalMs = intervalMs;
+  }
+
+  push(chunk: string): void {
+    this.buffer += chunk;
+    if (!this.timer) {
+      this.timer = setTimeout(() => {
+        this.flush().catch(() => {}); // notify() catches internally; guard against edge cases
+      }, this.intervalMs);
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    if (this.buffer.length > 0) {
+      const text = this.buffer;
+      this.buffer = "";
+      await this.flushFn(text);
+    }
+  }
+
+  /** Cancel any pending flush and discard buffered text. Use on error to prevent stale delta leaks. */
+  cancel(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.buffer = "";
+  }
+}
+
+/**
  * Process a chat job using the new agent loop (behind CHAT_AGENT_QUEUE_ENABLED flag).
  * Same outer contract as the legacy path: saves reply, updates response time, sends notifications.
+ * Streams tokens to frontend via Redis pub/sub -> WebSocket in real-time.
  */
 async function processWithAgentLoop(
   job: Job<ChatJobData, ChatJobResult>,
@@ -478,60 +529,106 @@ async function processWithAgentLoop(
   const { updateMessageResponseTime } = await import("../../chat/tools");
 
   let literatureEmitted = false;
+  let turnIndex = 0;
+  let streamStarted = false;
 
-  const result = await runChatAgent({
-    conversationId,
-    message,
-    uploadedDatasets: conversationState.values.uploadedDatasets,
-    loadHistory: true, // Queue path always stores messages
-    onToolResult: async (info) => {
-      // 1. Update conversation state in DB + notify frontend
-      if (conversationState.id) {
-        try {
-          const { updateConversationState } = await import(
-            "../../../db/operations"
-          );
-          await updateConversationState(conversationState.id, {
-            ...conversationState.values,
-            agentProgress: {
-              stage: `tool:${info.toolName}`,
-              toolCallCount: info.toolCallCount,
-              lastToolCallId: info.toolCallId,
-              isError: info.result.isError ?? false,
-            },
-          });
-          await notifyStateUpdated(
-            job.id!,
-            conversationId,
-            conversationState.id,
-          );
-        } catch (err) {
-          logger.warn(
-            { error: err },
-            "worker_conversation_state_update_failed",
-          );
-        }
-      }
-
-      // 2. Emit backward-compatible progress stages
-      if (info.toolName === "literature_search" && !literatureEmitted) {
-        literatureEmitted = true;
-        await job.updateProgress({
-          stage: "literature",
-          percent: 40,
-        } as JobProgress);
-        await notifyJobProgress(job.id!, conversationId, "literature", 40);
-      }
-    },
+  const streamBuffer = new StreamBuffer(async (batchedText) => {
+    await notifyStreamDelta(job.id!, conversationId, messageId, batchedText, turnIndex);
   });
 
-  // Handle truncation — use UnrecoverableError to skip BullMQ retries
-  // (same prompt will hit same token limit, retrying wastes 3 attempts)
+  let result;
+  try {
+    result = await runChatAgent({
+      conversationId,
+      message,
+      uploadedDatasets: conversationState.values.uploadedDatasets,
+      loadHistory: true, // Queue path always stores messages
+      onTextDelta: (delta) => {
+        if (!streamStarted) {
+          streamStarted = true;
+          turnIndex++;
+          // Fire-and-forget: ordering vs first delta is best-effort.
+          // Frontend handles delta-before-start gracefully (see frontend contract).
+          // notify() catches internally so no unhandled rejection risk.
+          void notifyStreamStart(job.id!, conversationId, messageId, turnIndex);
+        }
+        streamBuffer.push(delta);
+      },
+      onStreamPause: async () => {
+        // Called by loop.ts BEFORE tool execution starts (after finalMessage returns)
+        if (streamStarted) {
+          await streamBuffer.flush();
+          await notifyStreamEnd(job.id!, conversationId, messageId, false, turnIndex, "paused");
+          streamStarted = false;
+        }
+      },
+      onToolResult: async (info) => {
+        // 1. Update conversation state in DB + notify frontend
+        if (conversationState.id) {
+          try {
+            const { updateConversationState } = await import(
+              "../../../db/operations"
+            );
+            await updateConversationState(conversationState.id, {
+              ...conversationState.values,
+              agentProgress: {
+                stage: `tool:${info.toolName}`,
+                toolCallCount: info.toolCallCount,
+                lastToolCallId: info.toolCallId,
+                isError: info.result.isError ?? false,
+              },
+            });
+            await notifyStateUpdated(
+              job.id!,
+              conversationId,
+              conversationState.id,
+            );
+          } catch (err) {
+            logger.warn(
+              { error: err },
+              "worker_conversation_state_update_failed",
+            );
+          }
+        }
+
+        // 2. Emit backward-compatible progress stages
+        if (info.toolName === "literature_search" && !literatureEmitted) {
+          literatureEmitted = true;
+          await job.updateProgress({
+            stage: "literature",
+            percent: 40,
+          } as JobProgress);
+          await notifyJobProgress(job.id!, conversationId, "literature", 40);
+        }
+      },
+    });
+  } catch (err) {
+    // Cancel pending buffer to prevent stale deltas leaking into retry attempts
+    streamBuffer.cancel();
+    throw err;
+  }
+
+  // Check truncation BEFORE emitting final stream_end.
+  // Truncated responses should not be marked as final — the job will fail.
   if (!result.replyText || result.hitMaxTokens) {
+    if (streamStarted) {
+      // Flush remaining buffered text so partial answer is delivered, then signal error
+      await streamBuffer.flush();
+      await notifyStreamEnd(job.id!, conversationId, messageId, false, turnIndex, "truncated");
+    } else {
+      streamBuffer.cancel();
+    }
+    // Don't emit job:failed here — the outer catch in processChatJob
+    // already handles it for UnrecoverableError (line 441-448)
     const { UnrecoverableError } = await import("bullmq");
     throw new UnrecoverableError(
       "Agent loop response truncated (max_tokens)",
     );
+  }
+
+  // Flush remaining streamed text (deltas already delivered to frontend)
+  if (streamStarted) {
+    await streamBuffer.flush();
   }
 
   // Critical: persist the reply first. If this fails, retrying is correct
@@ -543,6 +640,10 @@ async function processWithAgentLoop(
   // Best-effort: progress updates and notifications. Reply is already saved,
   // so failures here should not trigger a retry or mark the job as failed.
   try {
+    // Signal stream complete AFTER durable write succeeds
+    if (streamStarted) {
+      await notifyStreamEnd(job.id!, conversationId, messageId, true, turnIndex, "complete");
+    }
     await job.updateProgress({ stage: "reply", percent: 90 } as JobProgress);
     await notifyJobProgress(job.id!, conversationId, "reply", 90);
     await notifyMessageUpdated(job.id!, conversationId, messageId);

--- a/src/services/queue/workers/chat.worker.ts
+++ b/src/services/queue/workers/chat.worker.ts
@@ -615,7 +615,11 @@ async function processWithAgentLoop(
       },
     });
   } catch (err) {
-    // Cancel pending buffer to prevent stale deltas leaking into retry attempts
+    // Emit stream_end so frontend exits streaming state before retry
+    if (streamStarted) {
+      await streamBuffer.flush().catch(() => {});
+      await notifyStreamEnd(job.id!, conversationId, messageId, false, turnIndex, "error").catch(() => {});
+    }
     await streamBuffer.cancel();
     throw err;
   }

--- a/src/services/queue/workers/chat.worker.ts
+++ b/src/services/queue/workers/chat.worker.ts
@@ -547,9 +547,10 @@ async function processWithAgentLoop(
         if (!streamStarted) {
           streamStarted = true;
           turnIndex++;
-          // Fire-and-forget: ordering vs first delta is best-effort.
+          // Fire-and-forget: stream_start vs first delta ordering is best-effort.
           // Frontend handles delta-before-start gracefully (see frontend contract).
-          // notify() catches internally so no unhandled rejection risk.
+          // Pushing synchronously avoids race where deferred first delta lands
+          // out of order or under wrong turnIndex.
           void notifyStreamStart(job.id!, conversationId, messageId, turnIndex);
         }
         streamBuffer.push(delta);
@@ -610,19 +611,24 @@ async function processWithAgentLoop(
 
   // Check truncation BEFORE emitting final stream_end.
   // Truncated responses should not be marked as final — the job will fail.
-  if (!result.replyText || result.hitMaxTokens) {
+  if (result.hitMaxTokens) {
     if (streamStarted) {
-      // Flush remaining buffered text so partial answer is delivered, then signal error
       await streamBuffer.flush();
       await notifyStreamEnd(job.id!, conversationId, messageId, false, turnIndex, "truncated");
     } else {
       streamBuffer.cancel();
     }
-    // Don't emit job:failed here — the outer catch in processChatJob
-    // already handles it for UnrecoverableError (line 441-448)
     const { UnrecoverableError } = await import("bullmq");
     throw new UnrecoverableError(
       "Agent loop response truncated (max_tokens)",
+    );
+  }
+
+  if (!result.replyText) {
+    streamBuffer.cancel();
+    const { UnrecoverableError } = await import("bullmq");
+    throw new UnrecoverableError(
+      "Agent loop produced empty reply",
     );
   }
 
@@ -637,23 +643,27 @@ async function processWithAgentLoop(
   await updateMessage(messageId, { content: result.replyText });
   await updateMessageResponseTime(messageId, responseTime);
 
-  // Best-effort: progress updates and notifications. Reply is already saved,
-  // so failures here should not trigger a retry or mark the job as failed.
-  try {
-    // Signal stream complete AFTER durable write succeeds
-    if (streamStarted) {
-      await notifyStreamEnd(job.id!, conversationId, messageId, true, turnIndex, "complete");
-    }
-    await job.updateProgress({ stage: "reply", percent: 90 } as JobProgress);
-    await notifyJobProgress(job.id!, conversationId, "reply", 90);
-    await notifyMessageUpdated(job.id!, conversationId, messageId);
-    await notifyJobCompleted(job.id!, conversationId, messageId);
-  } catch (notifyErr) {
-    logger.warn(
-      { error: notifyErr, messageId, jobId: job.id },
-      "chat_job_post_reply_notify_failed",
+  // Best-effort notifications. Reply is already saved, so failures here
+  // should not trigger a retry. Each notification is independent so one
+  // failing (e.g. transient Redis hiccup) doesn't block the others.
+  if (streamStarted) {
+    await notifyStreamEnd(job.id!, conversationId, messageId, true, turnIndex, "complete").catch((e) =>
+      logger.warn({ error: e, messageId }, "stream_end_notify_failed"),
     );
   }
+  await job.updateProgress({ stage: "reply", percent: 90 } as JobProgress).catch((e) =>
+    logger.warn({ error: e, messageId }, "job_progress_update_failed"),
+  );
+  await notifyJobProgress(job.id!, conversationId, "reply", 90).catch((e) =>
+    logger.warn({ error: e, messageId }, "job_progress_notify_failed"),
+  );
+  // Critical for frontend: these tell the client the response is ready
+  await notifyMessageUpdated(job.id!, conversationId, messageId).catch((e) =>
+    logger.warn({ error: e, messageId }, "message_updated_notify_failed"),
+  );
+  await notifyJobCompleted(job.id!, conversationId, messageId).catch((e) =>
+    logger.warn({ error: e, messageId }, "job_completed_notify_failed"),
+  );
 
   logger.info(
     {

--- a/src/services/websocket/handler.ts
+++ b/src/services/websocket/handler.ts
@@ -240,7 +240,10 @@ export function broadcastToConversation(conversationId: string, message: object)
   }
 
   if (successCount > 0 || errorCount > 0) {
-    logger.info(
+    // Use debug for high-frequency delta events to avoid log explosion
+    const msgType = (message as any)?.type;
+    const logFn = msgType === "message:delta" ? logger.debug : logger.info;
+    logFn.call(logger,
       { conversationId, successCount, errorCount },
       "ws_broadcast_completed",
     );

--- a/src/services/websocket/subscribe.ts
+++ b/src/services/websocket/subscribe.ts
@@ -38,7 +38,9 @@ export async function startRedisSubscription() {
         // Broadcast to all WebSocket clients in this conversation
         broadcastToConversation(conversationId, notification);
 
-        logger.info(
+        // Use debug for high-frequency delta events to avoid log explosion
+        const logFn = notification.type === "message:delta" ? logger.debug : logger.info;
+        logFn.call(logger,
           {
             type: notification.type,
             jobId: notification.jobId,


### PR DESCRIPTION
## Summary

- Streams tokens from Claude to frontend in real-time via existing Redis pub/sub -> WebSocket infrastructure
- Uses Anthropic SDK `client.messages.stream()` with 50ms micro-batched deltas (StreamBuffer class)
- Three new WebSocket notification types: `message:stream_start`, `message:delta`, `message:stream_end`
- `stream_end` includes `reason: "paused" | "truncated" | "complete"` for unambiguous event contract
- Pre-tool `onStreamPause` hook fires BEFORE tool execution (not after) so frontend knows tools are running immediately
- `stream_end(complete)` emitted only after durable DB write to prevent false "done" signals on retry
- Buffer cleanup on error prevents stale deltas leaking into BullMQ retry attempts
- Debug-level logging for delta events to avoid log explosion at scale
- Fully backward compatible: non-streaming callers (in-process mode, legacy pipeline) unchanged

## Files Changed (8)

- `src/chat-agent/types.ts` - Added `onTextDelta` + `onStreamPause` callbacks to AgentLoopConfig
- `src/chat-agent/loop.ts` - Conditional `client.messages.stream()` + pre-tool pause hook
- `src/chat-agent/runner.ts` - Pass through streaming callbacks
- `src/services/queue/types.ts` - 3 new notification types + delta/isFinal/turnIndex/reason fields
- `src/services/queue/notify.ts` - `notify()` quiet option + 3 streaming helpers
- `src/services/queue/workers/chat.worker.ts` - StreamBuffer + streaming wiring in processWithAgentLoop
- `src/services/websocket/subscribe.ts` - Debug logging for delta events
- `src/services/websocket/handler.ts` - Debug logging for delta events

## Frontend Contract

Three new WebSocket event types to handle:
```json
{ "type": "message:stream_start", "messageId": "...", "turnIndex": 1 }
{ "type": "message:delta", "messageId": "...", "delta": "Hello ", "turnIndex": 1 }
{ "type": "message:stream_end", "messageId": "...", "isFinal": true, "turnIndex": 1, "reason": "complete" }
```

Frontend should: append deltas to message bubble, clear on `stream_end(paused)`, finalize on `stream_end(complete)`, handle delta-before-start gracefully.

## Test plan

- [x] TypeScript type check passes (backend, zero errors)
- [x] StreamBuffer unit tests (5/5: batching, cancel, auto-flush, empty no-op, separate batches)
- [x] Anthropic SDK `.stream()` method verified
- [x] Local queue mode test: simple query - correct event sequence
- [x] Local queue mode test: research query with tool call - correct event sequence
- [x] Non-streaming fallback: in-process mode unchanged
- [ ] Frontend integration (separate PR)
- [ ] Staging E2E test after frontend wiring