### PR TITLE
Added SSE streaming to chat agent

### DIFF
--- a/src/chat-agent/loop.ts
+++ b/src/chat-agent/loop.ts
@@ -57,7 +57,19 @@ export async function runAgentLoop(
       tools: !isAtCap && toolDefs.length > 0 ? toolDefs : undefined,
     };
 
-    const response = await client.messages.create(requestParams);
+    let response: Anthropic.Message;
+
+    if (config.onTextDelta) {
+      // Streaming path: tokens delivered via callback as they arrive
+      const stream = client.messages.stream(requestParams);
+      stream.on("text", (text) => {
+        config.onTextDelta!(text);
+      });
+      response = await stream.finalMessage();
+    } else {
+      // Non-streaming path: unchanged behavior for callers without callback
+      response = await client.messages.create(requestParams);
+    }
 
     // Track token usage
     if (response.usage) {
@@ -91,6 +103,15 @@ export async function runAgentLoop(
         .map((block) => block.text)
         .join("\n\n");
       break;
+    }
+
+    // Notify caller that streaming is pausing for tool execution
+    if (config.onStreamPause) {
+      try {
+        await config.onStreamPause();
+      } catch (err) {
+        logger.warn({ error: err }, "on_stream_pause_callback_failed");
+      }
     }
 
     // stop_reason === "tool_use" — execute tools

--- a/src/chat-agent/runner.ts
+++ b/src/chat-agent/runner.ts
@@ -5,8 +5,8 @@
  * All imports are dynamic to avoid TDZ issues in the worker process.
  */
 
-import type { ToolCallInfo } from "./types";
 import type { MessageParam } from "@anthropic-ai/sdk/resources/messages";
+import type { ToolCallInfo } from "./types";
 
 // ---------------------------------------------------------------------------
 // Public interface
@@ -75,9 +75,7 @@ DATA SAFETY
 // Core runner
 // ---------------------------------------------------------------------------
 
-export async function runChatAgent(
-  params: RunChatAgentParams,
-): Promise<RunChatAgentResult> {
+export async function runChatAgent(params: RunChatAgentParams): Promise<RunChatAgentResult> {
   // Dynamic imports for TDZ safety in worker processes
   const logger = (await import("../utils/logger")).default;
 
@@ -90,12 +88,9 @@ export async function runChatAgent(
     throw new Error("ANTHROPIC_API_KEY is not configured");
   }
 
-  const model =
-    process.env.CHAT_AGENT_MODEL || "claude-sonnet-4-6";
-  const maxToolCalls =
-    parseInt(process.env.CHAT_AGENT_MAX_TOOL_CALLS || "") || 10;
-  const maxTokens =
-    parseInt(process.env.CHAT_AGENT_MAX_TOKENS || "") || 4096;
+  const model = process.env.CHAT_AGENT_MODEL || "claude-sonnet-4-6";
+  const maxToolCalls = parseInt(process.env.CHAT_AGENT_MAX_TOOL_CALLS || "") || 10;
+  const maxTokens = parseInt(process.env.CHAT_AGENT_MAX_TOKENS || "") || 4096;
 
   // --- 3. Build system prompt + dataset context for user message ---
   const systemPrompt = AGENT_SYSTEM_PROMPT;
@@ -128,10 +123,7 @@ export async function runChatAgent(
     try {
       const { getMessagesByConversation } = await import("../db/operations");
       // Fetch 4 newest messages, skip current (first), yielding up to 3 prior exchanges
-      const recentMessages = await getMessagesByConversation(
-        params.conversationId,
-        4,
-      );
+      const recentMessages = await getMessagesByConversation(params.conversationId, 4);
 
       if (recentMessages && recentMessages.length > 1) {
         const previous = recentMessages.slice(1).reverse();
@@ -139,15 +131,13 @@ export async function runChatAgent(
         for (const msg of previous) {
           if (msg.question && msg.content) {
             conversationHistory.push({
-              role: "user",
               content: msg.question,
+              role: "user",
             });
             conversationHistory.push({
-              role: "assistant",
               content:
-                msg.content.length > 4000
-                  ? msg.content.substring(0, 4000) + "..."
-                  : msg.content,
+                msg.content.length > 4000 ? msg.content.substring(0, 4000) + "..." : msg.content,
+              role: "assistant",
             });
           }
         }
@@ -158,12 +148,12 @@ export async function runChatAgent(
           conversationId: params.conversationId,
           historyExchanges: conversationHistory.length / 2,
         },
-        "conversation_history_loaded",
+        "conversation_history_loaded"
       );
     } catch (err) {
       logger.warn(
-        { error: err, conversationId: params.conversationId },
-        "conversation_history_load_failed",
+        { conversationId: params.conversationId, error: err },
+        "conversation_history_load_failed"
       );
       // Continue without history — don't break the chat
     }
@@ -175,24 +165,24 @@ export async function runChatAgent(
   const agentResult = await runAgentLoop(
     userMessage,
     {
-      model,
-      systemPrompt,
-      maxToolCalls,
-      maxTokens,
       apiKey,
-      onToolResult: params.onToolResult,
-      onTextDelta: params.onTextDelta,
+      maxTokens,
+      maxToolCalls,
+      model,
       onStreamPause: params.onStreamPause,
+      onTextDelta: params.onTextDelta,
+      onToolResult: params.onToolResult,
+      systemPrompt,
     },
-    conversationHistory.length > 0 ? conversationHistory : undefined,
+    conversationHistory.length > 0 ? conversationHistory : undefined
   );
 
   // --- 6. Return unified result ---
   return {
+    hitMaxTokens: agentResult.hitMaxTokens ?? false,
     replyText: agentResult.finalText,
     toolCallCount: agentResult.toolCallCount,
     totalInputTokens: agentResult.totalInputTokens,
     totalOutputTokens: agentResult.totalOutputTokens,
-    hitMaxTokens: agentResult.hitMaxTokens ?? false,
   };
 }

--- a/src/chat-agent/runner.ts
+++ b/src/chat-agent/runner.ts
@@ -25,6 +25,10 @@ export interface RunChatAgentParams {
   loadHistory?: boolean;
   /** Called after each tool execution. Callers customise for DB updates, notifications, etc. */
   onToolResult?: (info: ToolCallInfo) => Promise<void>;
+  /** Called on each text chunk during streaming. Synchronous to avoid backpressure. */
+  onTextDelta?: (delta: string) => void;
+  /** Called after LLM response with tool_use blocks, BEFORE tools execute. */
+  onStreamPause?: () => Promise<void>;
 }
 
 export interface RunChatAgentResult {
@@ -177,6 +181,8 @@ export async function runChatAgent(
       maxTokens,
       apiKey,
       onToolResult: params.onToolResult,
+      onTextDelta: params.onTextDelta,
+      onStreamPause: params.onStreamPause,
     },
     conversationHistory.length > 0 ? conversationHistory : undefined,
   );

--- a/src/chat-agent/runner.ts
+++ b/src/chat-agent/runner.ts
@@ -121,12 +121,13 @@ export async function runChatAgent(params: RunChatAgentParams): Promise<RunChatA
 
   if (params.loadHistory !== false) {
     try {
-      const { getMessagesByConversation } = await import("../db/operations");
-      // Fetch 4 newest messages, skip current (first), yielding up to 3 prior exchanges
-      const recentMessages = await getMessagesByConversation(params.conversationId, 4);
+      const { getCompletedMessagesByConversation } = await import("../db/operations");
+      // Up to 3 prior completed exchanges. The COMPLETE-only helper excludes
+      // the current in-flight row and any pending orphans, so no slicing.
+      const recentMessages = await getCompletedMessagesByConversation(params.conversationId, 3);
 
-      if (recentMessages && recentMessages.length > 1) {
-        const previous = recentMessages.slice(1).reverse();
+      if (recentMessages && recentMessages.length > 0) {
+        const previous = recentMessages.reverse();
 
         for (const msg of previous) {
           if (msg.question && msg.content) {

--- a/src/chat-agent/types.ts
+++ b/src/chat-agent/types.ts
@@ -44,6 +44,10 @@ export interface AgentLoopConfig {
   apiKey: string;
   /** Called after each tool execution. Use for DB state updates, progress notifications, etc. */
   onToolResult?: (info: ToolCallInfo) => Promise<void>;
+  /** Called on each text chunk during streaming. Synchronous to avoid backpressure on the Anthropic stream. */
+  onTextDelta?: (delta: string) => void;
+  /** Called after LLM response with tool_use blocks, BEFORE tools execute. Use to flush stream buffer and notify frontend. */
+  onStreamPause?: () => Promise<void>;
 }
 
 /**

--- a/src/db/operations.ts
+++ b/src/db/operations.ts
@@ -36,6 +36,8 @@ export interface DbConversationState {
   updated_at?: string;
 }
 
+export type MessageStatus = "PENDING" | "COMPLETE" | "FAILED";
+
 export interface Message {
   id?: string;
   conversation_id: string;
@@ -47,6 +49,7 @@ export interface Message {
   response_time?: number;
   source?: string;
   files?: Array<{ name: string; size: number; type: string }>;
+  status?: MessageStatus;
 }
 
 // User operations
@@ -151,6 +154,36 @@ export async function getMessagesByConversation(conversationId: string, limit?: 
   if (error) {
     logger.error(
       `[getMessagesByConversation] Error getting messages by conversation: ${error.message}`
+    );
+    throw error;
+  }
+  return data;
+}
+
+/**
+ * Chat-only history loader. Returns COMPLETE rows only — PENDING (in-flight
+ * or orphaned) and FAILED rows are excluded so the chat agent never sees a
+ * null-content row in its context window. Use this from chat-side history
+ * builders only; deep-research callers should use getMessagesByConversation
+ * which returns all rows.
+ */
+export async function getCompletedMessagesByConversation(conversationId: string, limit?: number) {
+  let query = supabase
+    .from("messages")
+    .select("*, state:states(*)")
+    .eq("conversation_id", conversationId)
+    .eq("status", "COMPLETE")
+    .order("created_at", { ascending: false });
+
+  if (limit) {
+    query = query.limit(limit);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    logger.error(
+      `[getCompletedMessagesByConversation] Error getting completed messages: ${error.message}`
     );
     throw error;
   }

--- a/src/db/setup.sql
+++ b/src/db/setup.sql
@@ -59,6 +59,8 @@ CREATE TABLE messages (
   response_time INTEGER, -- in milliseconds
   source TEXT DEFAULT 'ui', -- 'ui', 'twitter', etc.
   files JSONB, -- stores file metadata for uploads
+  status TEXT NOT NULL DEFAULT 'PENDING'
+    CHECK (status IN ('PENDING', 'COMPLETE', 'FAILED')),
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
@@ -71,6 +73,8 @@ CREATE INDEX idx_messages_conversation_id ON messages(conversation_id);
 CREATE INDEX idx_messages_user_id ON messages(user_id);
 CREATE INDEX idx_messages_created_at ON messages(created_at DESC);
 CREATE INDEX idx_messages_state_id ON messages(state_id);
+-- Partial index for the periodic sweeper to find stuck-pending rows fast
+CREATE INDEX idx_messages_status_pending ON messages(created_at) WHERE status = 'PENDING';
 
 -- GIN index for JSONB fields (efficient for JSON queries)
 CREATE INDEX idx_states_values ON states USING GIN (values);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,23 +3,26 @@ import "./utils/canvas-polyfill";
 
 import { cors } from "@elysiajs/cors";
 import { Elysia } from "elysia";
+import { adminJobsRoute } from "./routes/admin/jobs";
+import { createQueueDashboard } from "./routes/admin/queue-dashboard";
 import { artifactsRoute } from "./routes/artifacts";
 import { authRoute } from "./routes/auth";
 import { chatRoute } from "./routes/chat";
 import { clarificationRoute } from "./routes/clarification";
+import { deepResearchBranchRoute } from "./routes/deep-research/branch";
+import { deepResearchPaperRoute } from "./routes/deep-research/paper";
 import { deepResearchStartRoute } from "./routes/deep-research/start";
 import { deepResearchStatusRoute } from "./routes/deep-research/status";
-import { deepResearchPaperRoute } from "./routes/deep-research/paper";
-import { deepResearchBranchRoute } from "./routes/deep-research/branch";
 import { filesRoute } from "./routes/files";
+// BullMQ Queue imports (conditional)
+import { closeConnections, isJobQueueEnabled } from "./services/queue/connection";
+import { cleanupDeadConnections, websocketHandler } from "./services/websocket/handler";
+import { startRedisSubscription, stopRedisSubscription } from "./services/websocket/subscribe";
 import logger from "./utils/logger";
 
-// BullMQ Queue imports (conditional)
-import { isJobQueueEnabled, closeConnections } from "./services/queue/connection";
-import { websocketHandler, cleanupDeadConnections } from "./services/websocket/handler";
-import { startRedisSubscription, stopRedisSubscription } from "./services/websocket/subscribe";
-import { createQueueDashboard } from "./routes/admin/queue-dashboard";
-import { adminJobsRoute } from "./routes/admin/jobs";
+// Tracks the in-process sweeper timer (set when USE_JOB_QUEUE=false) so
+// graceful shutdown can clear it.
+let messageSweeperTimer: NodeJS.Timeout | null = null;
 
 // ============================================================================
 // CORS Configuration - Security Critical
@@ -34,7 +37,9 @@ const DEFAULT_ALLOWED_ORIGINS = [
 ];
 
 const ALLOWED_ORIGINS: string[] = process.env.ALLOWED_ORIGINS
-  ? process.env.ALLOWED_ORIGINS.split(",").map((o) => o.trim()).filter(Boolean)
+  ? process.env.ALLOWED_ORIGINS.split(",")
+      .map((o) => o.trim())
+      .filter(Boolean)
   : DEFAULT_ALLOWED_ORIGINS;
 
 // Log CORS configuration on startup
@@ -67,7 +72,7 @@ function validateCorsOrigin(request: Request): boolean {
   }
 
   // Log rejected origin for security monitoring
-  logger.warn({ origin, allowedOrigins: ALLOWED_ORIGINS }, "cors_origin_rejected");
+  logger.warn({ allowedOrigins: ALLOWED_ORIGINS, origin }, "cors_origin_rejected");
   return false;
 }
 
@@ -77,19 +82,12 @@ const app = new Elysia()
   // Enable CORS with origin whitelist
   .use(
     cors({
-      origin: validateCorsOrigin,
+      allowedHeaders: ["Content-Type", "Authorization", "X-API-Key", "X-Requested-With"],
       credentials: true,
-      allowedHeaders: [
-        "Content-Type",
-        "Authorization",
-        "X-API-Key",
-        "X-Requested-With",
-      ],
-      exposeHeaders: [
-        "Content-Type",
-      ],
+      exposeHeaders: ["Content-Type"],
       maxAge: 86400, // Cache preflight for 24 hours
-    }),
+      origin: validateCorsOrigin,
+    })
   )
 
   // ============================================================================
@@ -120,10 +118,7 @@ const app = new Elysia()
   // Basic request logging
   .onRequest(({ request }) => {
     if (!logger) return;
-    logger.info(
-      { method: request.method, url: request.url },
-      "incoming_request",
-    );
+    logger.info({ method: request.method, url: request.url }, "incoming_request");
   })
   .onError(({ code, error }) => {
     if (!logger) return;
@@ -144,11 +139,9 @@ const app = new Elysia()
 
     // Inject SEO metadata from environment variables
     const seoTitle = process.env.SEO_TITLE || "BioAgents Chat";
-    const seoDescription =
-      process.env.SEO_DESCRIPTION || "AI-powered chat interface";
+    const seoDescription = process.env.SEO_DESCRIPTION || "AI-powered chat interface";
     const faviconUrl = process.env.FAVICON_URL || "/favicon.ico";
-    const ogImageUrl =
-      process.env.OG_IMAGE_URL || "https://bioagents.xyz/og-image.png";
+    const ogImageUrl = process.env.OG_IMAGE_URL || "https://bioagents.xyz/og-image.png";
 
     htmlContent = htmlContent
       .replace(/\{\{SEO_TITLE\}\}/g, seoTitle)
@@ -221,7 +214,7 @@ const app = new Elysia()
           enabled: true,
           redis: "connected",
         };
-      } catch (error) {
+      } catch (_error) {
         health.jobQueue = {
           enabled: true,
           redis: "disconnected",
@@ -240,8 +233,8 @@ const app = new Elysia()
   // Suppress Chrome DevTools 404 error
   .get("/.well-known/appspecific/com.chrome.devtools.json", () => {
     return new Response(JSON.stringify({}), {
-      status: 200,
       headers: { "Content-Type": "application/json" },
+      status: 200,
     });
   })
 
@@ -265,14 +258,14 @@ if (queueDashboard) {
   if (ADMIN_PASSWORD) {
     app.onBeforeHandle(({ request, set }) => {
       const url = new URL(request.url);
-      
+
       // Only protect /admin/* routes
       if (!url.pathname.startsWith("/admin")) {
         return;
       }
 
       const authHeader = request.headers.get("Authorization");
-      
+
       // Check for valid basic auth
       if (!authHeader || !authHeader.startsWith("Basic ")) {
         set.status = 401;
@@ -297,9 +290,15 @@ if (queueDashboard) {
         return new Response("Unauthorized", { status: 401 });
       }
     });
-    logger.info({ path: "/admin/queues", authEnabled: true }, "bull_board_dashboard_mounted_with_auth");
+    logger.info(
+      { authEnabled: true, path: "/admin/queues" },
+      "bull_board_dashboard_mounted_with_auth"
+    );
   } else {
-    logger.info({ path: "/admin/queues", authEnabled: false }, "bull_board_dashboard_mounted_no_auth");
+    logger.info(
+      { authEnabled: false, path: "/admin/queues" },
+      "bull_board_dashboard_mounted_no_auth"
+    );
   }
 
   app.use(queueDashboard);
@@ -327,11 +326,9 @@ app
 
     // Inject SEO metadata from environment variables
     const seoTitle = process.env.SEO_TITLE || "BioAgents Chat";
-    const seoDescription =
-      process.env.SEO_DESCRIPTION || "AI-powered chat interface";
+    const seoDescription = process.env.SEO_DESCRIPTION || "AI-powered chat interface";
     const faviconUrl = process.env.FAVICON_URL || "/favicon.ico";
-    const ogImageUrl =
-      process.env.OG_IMAGE_URL || "https://bioagents.xyz/og-image.png";
+    const ogImageUrl = process.env.OG_IMAGE_URL || "https://bioagents.xyz/og-image.png";
 
     htmlContent = htmlContent
       .replace(/\{\{SEO_TITLE\}\}/g, seoTitle)
@@ -355,26 +352,26 @@ const hasSecret = !!process.env.BIOAGENTS_SECRET;
 
 app.listen(
   {
-    port,
     hostname,
+    port,
   },
   async () => {
     if (logger) {
       logger.info({ url: `http://${hostname}:${port}` }, "server_listening");
       logger.info(
         {
-          nodeEnv: process.env.NODE_ENV || "development",
-          isProduction,
           authRequired: isProduction,
-          secretConfigured: hasSecret,
+          isProduction,
           jobQueueEnabled: isJobQueueEnabled(),
+          nodeEnv: process.env.NODE_ENV || "development",
+          secretConfigured: hasSecret,
         },
-        "auth_configuration",
+        "auth_configuration"
       );
     } else {
       console.log(`Server listening on http://${hostname}:${port}`);
       console.log(
-        `Auth config: NODE_ENV=${process.env.NODE_ENV}, production=${isProduction}, secretConfigured=${hasSecret}`,
+        `Auth config: NODE_ENV=${process.env.NODE_ENV}, production=${isProduction}, secretConfigured=${hasSecret}`
       );
       console.log(`Job queue: ${isJobQueueEnabled() ? "enabled" : "disabled"}`);
     }
@@ -400,8 +397,17 @@ app.listen(
       setInterval(() => {
         cleanupDeadConnections();
       }, 30000);
+    } else {
+      // In-process deployment (USE_JOB_QUEUE=false): no worker process exists,
+      // so the BullMQ-based message sweeper would never run. Fall back to a
+      // setInterval-based sweeper here so chat-mode orphans still get cleaned
+      // up after a process death/deploy.
+      const { startInProcessMessageSweeper } = await import(
+        "./services/queue/workers/message-sweeper.worker"
+      );
+      messageSweeperTimer = startInProcessMessageSweeper();
     }
-  },
+  }
 );
 
 // Graceful shutdown handler
@@ -413,6 +419,12 @@ async function gracefulShutdown(signal: string) {
   }
 
   try {
+    // Stop the in-process message sweeper if it was started
+    if (messageSweeperTimer) {
+      clearInterval(messageSweeperTimer);
+      messageSweeperTimer = null;
+    }
+
     // Stop Redis subscription
     if (isJobQueueEnabled()) {
       await stopRedisSubscription();

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -363,30 +363,19 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
     // Triggered when client sends Accept: text/event-stream header.
     // Non-SSE requests fall through to the existing queue/JSON paths below.
     // =========================================================================
-    const acceptsSSE = request.headers
-      .get("accept")
-      ?.includes("text/event-stream");
+    const acceptsSSE = request.headers.get("accept")?.includes("text/event-stream");
 
     if (acceptsSSE) {
-      logger.info(
-        { messageId: createdMessage.id, conversationId },
-        "chat_using_sse_mode",
-      );
+      logger.info({ conversationId, messageId: createdMessage.id }, "chat_using_sse_mode");
 
       // Import SSE dependencies at function scope (dynamic for TDZ safety)
       const { runChatAgent } = await import("../chat-agent/runner");
       const { fileUploadAgent } = await import("../agents/fileUpload");
-      const { getPendingFileIds, getFileStatus } = await import(
-        "../services/files/status"
+      const { getPendingFileIds, getFileStatus } = await import("../services/files/status");
+      const { getFileProcessQueue } = await import("../services/queue/queues");
+      const { getConversationState, updateMessage, updateConversationState } = await import(
+        "../db/operations"
       );
-      const { getFileProcessQueue } = await import(
-        "../services/queue/queues"
-      );
-      const {
-        getConversationState,
-        updateMessage,
-        updateConversationState,
-      } = await import("../db/operations");
 
       const encoder = new TextEncoder();
       const sseStartTime = Date.now();
@@ -395,14 +384,22 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
       let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 
       const stream = new ReadableStream({
+        cancel() {
+          // Client disconnected. Agent loop keeps running via the awaited
+          // runChatAgent call - DB save still happens. send() becomes no-op.
+          // Clear the heartbeat timer to prevent leak.
+          if (heartbeatTimer) {
+            clearInterval(heartbeatTimer);
+            heartbeatTimer = null;
+          }
+          logger.info({ messageId: createdMessage.id }, "chat_sse_client_disconnected");
+        },
         async start(controller) {
           // Helper: safe enqueue (swallows errors if client disconnected)
           const send = (event: string, data: unknown) => {
             try {
               controller.enqueue(
-                encoder.encode(
-                  `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`,
-                ),
+                encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`)
               );
             } catch {
               // Controller closed (client disconnected). Keep running so DB save happens.
@@ -416,9 +413,7 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
           // (up to 2 min) can easily exceed proxy idle limits.
           const sendHeartbeat = () => {
             try {
-              controller.enqueue(
-                encoder.encode(`: heartbeat ${Date.now()}\n\n`),
-              );
+              controller.enqueue(encoder.encode(`: heartbeat ${Date.now()}\n\n`));
             } catch {
               // Controller closed
             }
@@ -451,8 +446,8 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
             // can render its streaming bubble immediately. Then start heartbeats
             // to keep proxies alive during the silent file-wait period.
             send("init", {
-              messageId: createdMessage.id,
               conversationId,
+              messageId: createdMessage.id,
             });
             startHeartbeat();
 
@@ -470,8 +465,7 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
                 files,
                 userId,
               });
-              conversationStateRecord.values =
-                conversationStateForFiles.values;
+              conversationStateRecord.values = conversationStateForFiles.values;
             }
 
             // Path B: presigned S3 upload flow (usePresignedUpload.ts).
@@ -480,13 +474,11 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
             // chat.worker.ts:95-174 so SSE doesn't race with file processing.
             // Without this, the agent runs before uploaded datasets are ready.
             if (conversationStateRecord.id) {
-              const pendingFileIds = await getPendingFileIds(
-                conversationStateRecord.id,
-              );
+              const pendingFileIds = await getPendingFileIds(conversationStateRecord.id);
               if (pendingFileIds.length > 0) {
                 logger.info(
                   { messageId: createdMessage.id, pendingFileIds },
-                  "chat_sse_waiting_for_file_processing",
+                  "chat_sse_waiting_for_file_processing"
                 );
                 // CRITICAL: getFileProcessQueue() returns null when
                 // USE_JOB_QUEUE=false (queues.ts:120). Must null-guard before
@@ -504,8 +496,8 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
                     if (fileStatus?.status === "ready") break;
                     if (fileStatus?.status === "error") {
                       logger.warn(
-                        { messageId: createdMessage.id, fileId },
-                        "chat_sse_file_failed_continuing",
+                        { fileId, messageId: createdMessage.id },
+                        "chat_sse_file_failed_continuing"
                       );
                       break;
                     }
@@ -513,29 +505,23 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
                     // Secondary signal from BullMQ job state when queue exists
                     if (fileProcessQueue) {
                       const fileJob = await fileProcessQueue.getJob(fileId);
-                      const fileJobState = fileJob
-                        ? await fileJob.getState()
-                        : null;
+                      const fileJobState = fileJob ? await fileJob.getState() : null;
                       if (fileJobState === "completed" || !fileJob) break;
                       if (fileJobState === "failed") {
                         logger.warn(
-                          { messageId: createdMessage.id, fileId },
-                          "chat_sse_file_job_failed_continuing",
+                          { fileId, messageId: createdMessage.id },
+                          "chat_sse_file_job_failed_continuing"
                         );
                         break;
                       }
                     }
 
-                    await new Promise((r) =>
-                      setTimeout(r, pollIntervalMs),
-                    );
+                    await new Promise((r) => setTimeout(r, pollIntervalMs));
                   }
                 }
 
                 // Refresh conversation state to pick up uploadedDatasets
-                const fresh = await getConversationState(
-                  conversationStateRecord.id,
-                );
+                const fresh = await getConversationState(conversationStateRecord.id);
                 if (fresh) {
                   conversationStateRecord.values = fresh.values;
                 }
@@ -544,10 +530,19 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
 
             const result = await runChatAgent({
               conversationId,
-              message,
-              uploadedDatasets:
-                conversationStateRecord.values.uploadedDatasets,
               loadHistory: true,
+              message,
+              onStreamPause: async () => {
+                // Called by loop.ts AFTER finalMessage, BEFORE tool execution
+                if (streamStarted) {
+                  send("stream_end", {
+                    isFinal: false,
+                    reason: "paused",
+                    turnIndex,
+                  });
+                  streamStarted = false;
+                }
+              },
               onTextDelta: (delta) => {
                 if (!streamStarted) {
                   streamStarted = true;
@@ -556,17 +551,6 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
                 }
                 send("delta", { text: delta, turnIndex });
               },
-              onStreamPause: async () => {
-                // Called by loop.ts AFTER finalMessage, BEFORE tool execution
-                if (streamStarted) {
-                  send("stream_end", {
-                    isFinal: false,
-                    turnIndex,
-                    reason: "paused",
-                  });
-                  streamStarted = false;
-                }
-              },
               onToolResult: async (info) => {
                 // Mirror existing in-process path: update conversation state
                 if (!conversationStateRecord.id) return;
@@ -574,19 +558,20 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
                   await updateConversationState(conversationStateRecord.id, {
                     ...conversationStateRecord.values,
                     agentProgress: {
+                      isError: info.result.isError ?? false,
+                      lastToolCallId: info.toolCallId,
                       stage: `tool:${info.toolName}`,
                       toolCallCount: info.toolCallCount,
-                      lastToolCallId: info.toolCallId,
-                      isError: info.result.isError ?? false,
                     },
                   });
                 } catch (err) {
                   logger.warn(
                     { error: err, toolName: info.toolName },
-                    "conversation_state_update_failed",
+                    "conversation_state_update_failed"
                   );
                 }
               },
+              uploadedDatasets: conversationStateRecord.values.uploadedDatasets,
             });
 
             // === Truncation guard ===
@@ -596,32 +581,25 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
               if (streamStarted) {
                 send("stream_end", {
                   isFinal: false,
-                  turnIndex,
                   reason: "truncated",
+                  turnIndex,
                 });
               }
               send("error", {
+                message: "Response was truncated. Please try a shorter question.",
                 reason: "truncated",
-                message:
-                  "Response was truncated. Please try a shorter question.",
               });
               safeClose();
-              logger.warn(
-                { messageId: createdMessage.id },
-                "chat_sse_truncated",
-              );
+              logger.warn({ messageId: createdMessage.id }, "chat_sse_truncated");
               return;
             }
             if (!result.replyText) {
               send("error", {
-                reason: "empty_reply",
                 message: "No response generated. Please try again.",
+                reason: "empty_reply",
               });
               safeClose();
-              logger.warn(
-                { messageId: createdMessage.id },
-                "chat_sse_empty_reply",
-              );
+              logger.warn({ messageId: createdMessage.id }, "chat_sse_empty_reply");
               return;
             }
 
@@ -638,8 +616,8 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
             if (streamStarted) {
               send("stream_end", {
                 isFinal: true,
-                turnIndex,
                 reason: "complete",
+                turnIndex,
               });
             }
             send("done", { messageId: createdMessage.id });
@@ -647,56 +625,40 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
 
             logger.info(
               {
-                messageId: createdMessage.id,
                 conversationId,
+                messageId: createdMessage.id,
+                replyLength: result.replyText.length,
+                responseTime,
+                streaming: true,
                 toolCallCount: result.toolCallCount,
                 totalInputTokens: result.totalInputTokens,
                 totalOutputTokens: result.totalOutputTokens,
-                responseTime,
-                replyLength: result.replyText.length,
-                streaming: true,
               },
-              "chat_sse_completed",
+              "chat_sse_completed"
             );
           } catch (err) {
-            logger.error(
-              { error: err, messageId: createdMessage.id },
-              "chat_sse_error",
-            );
+            logger.error({ error: err, messageId: createdMessage.id }, "chat_sse_error");
             // Generic client-facing message -- raw err.message can leak
             // internal detail (Anthropic SDK errors, DB errors, etc.). Full
             // error is already captured in the logger.error above.
             send("error", {
-              reason: "agent_error",
               message: "Something went wrong while generating the response. Please try again.",
+              reason: "agent_error",
             });
             safeClose();
           }
         },
-        cancel() {
-          // Client disconnected. Agent loop keeps running via the awaited
-          // runChatAgent call - DB save still happens. send() becomes no-op.
-          // Clear the heartbeat timer to prevent leak.
-          if (heartbeatTimer) {
-            clearInterval(heartbeatTimer);
-            heartbeatTimer = null;
-          }
-          logger.info(
-            { messageId: createdMessage.id },
-            "chat_sse_client_disconnected",
-          );
-        },
       });
 
       return new Response(stream, {
-        status: 200,
         headers: {
-          "Content-Type": "text/event-stream",
           "Cache-Control": "no-cache",
           Connection: "keep-alive",
+          "Content-Type": "text/event-stream",
           // Disable nginx buffering - critical for real-time streaming
           "X-Accel-Buffering": "no",
         },
+        status: 200,
       });
     }
 

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -376,7 +376,10 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
     // Triggered when client sends Accept: text/event-stream header.
     // Non-SSE requests fall through to the existing queue/JSON paths below.
     // =========================================================================
-    const acceptsSSE = request.headers.get("accept")?.includes("text/event-stream");
+    // RFC 7231 §5.3.2 mandates case-insensitive media-type comparison; lowercase
+    // before substring match so non-browser clients with `text/Event-Stream` etc.
+    // don't silently fall through to the JSON path.
+    const acceptsSSE = request.headers.get("accept")?.toLowerCase().includes("text/event-stream");
 
     if (acceptsSSE) {
       logger.info({ conversationId, messageId: createdMessage.id }, "chat_using_sse_mode");

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -663,10 +663,12 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
               { error: err, messageId: createdMessage.id },
               "chat_sse_error",
             );
+            // Generic client-facing message -- raw err.message can leak
+            // internal detail (Anthropic SDK errors, DB errors, etc.). Full
+            // error is already captured in the logger.error above.
             send("error", {
               reason: "agent_error",
-              message:
-                err instanceof Error ? err.message : "Streaming failed",
+              message: "Something went wrong while generating the response. Please try again.",
             });
             safeClose();
           }

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -3,7 +3,11 @@ import { Elysia } from "elysia";
 import { authResolver } from "../middleware/authResolver";
 import { rateLimitMiddleware } from "../middleware/rateLimiter";
 import { ensureUserAndConversation, setupConversationData } from "../services/chat/setup";
-import { createMessageRecord, updateMessageResponseTime } from "../services/chat/tools";
+import {
+  createMessageRecord,
+  markMessageFailed,
+  updateMessageResponseTime,
+} from "../services/chat/tools";
 import type { ConversationState, State } from "../types/core";
 import type { ElysiaRouteContext } from "../types/elysia";
 import { asString, extractFiles, isBodyRecord } from "../utils/bodyParsing";
@@ -225,6 +229,14 @@ async function chatRetryHandler(ctx: ElysiaRouteContext<{ jobId: string }>) {
  * - USE_JOB_QUEUE=true: Enqueues to BullMQ and returns immediately
  */
 export async function chatHandler(ctx: ElysiaRouteContext) {
+  // Hoisted so the outer catch can mark the message FAILED on any handled
+  // terminal error (fileUploadAgent / runChatAgent / final DB write throws).
+  // Set immediately after createMessageRecord succeeds; null until then.
+  let createdMessageId: string | null = null;
+  // Set true after the durable status=COMPLETE write succeeds so a post-save
+  // throw (best-effort calls, logger, etc.) doesn't downgrade the row.
+  let replyPersisted = false;
+
   try {
     const { body, set, request } = ctx;
     const startTime = Date.now();
@@ -348,6 +360,7 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
     }
 
     const createdMessage = messageResult.message!;
+    createdMessageId = createdMessage.id;
 
     logger.info(
       {
@@ -395,6 +408,12 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
           logger.info({ messageId: createdMessage.id }, "chat_sse_client_disconnected");
         },
         async start(controller) {
+          // Tracks whether the COMPLETE durable write succeeded. The catch
+          // handler below uses this to avoid downgrading a successfully-saved
+          // reply to FAILED when a post-save step (e.g. logger / safeClose)
+          // throws.
+          let replyPersisted = false;
+
           // Helper: safe enqueue (swallows errors if client disconnected)
           const send = (event: string, data: unknown) => {
             try {
@@ -589,6 +608,7 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
                 message: "Response was truncated. Please try a shorter question.",
                 reason: "truncated",
               });
+              await markMessageFailed(createdMessage.id);
               safeClose();
               logger.warn({ messageId: createdMessage.id }, "chat_sse_truncated");
               return;
@@ -598,6 +618,7 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
                 message: "No response generated. Please try again.",
                 reason: "empty_reply",
               });
+              await markMessageFailed(createdMessage.id);
               safeClose();
               logger.warn({ messageId: createdMessage.id }, "chat_sse_empty_reply");
               return;
@@ -609,7 +630,9 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
             const responseTime = Date.now() - sseStartTime;
             await updateMessage(createdMessage.id, {
               content: result.replyText,
+              status: "COMPLETE",
             });
+            replyPersisted = true;
             await updateMessageResponseTime(createdMessage.id, responseTime);
 
             // === Terminal success signals (only after durable write) ===
@@ -645,6 +668,12 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
               message: "Something went wrong while generating the response. Please try again.",
               reason: "agent_error",
             });
+            // Only mark FAILED if the reply hasn't already been durably saved.
+            // A post-save throw (e.g. logger / safeClose / response-time write)
+            // must not downgrade a successful reply to FAILED.
+            if (!replyPersisted) {
+              await markMessageFailed(createdMessage.id);
+            }
             safeClose();
           }
         },
@@ -834,6 +863,7 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
     // Handle empty response from max_tokens truncation
     if (!replyText || agentResult.hitMaxTokens) {
       logger.error({ messageId: createdMessage.id }, "agent_loop_empty_max_tokens");
+      await markMessageFailed(createdMessage.id);
       set.status = 500;
       return {
         error: "Response was truncated. Please try a shorter question.",
@@ -865,7 +895,9 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
     const { updateMessage } = await import("../db/operations");
     await updateMessage(createdMessage.id, {
       content: replyText,
+      status: "COMPLETE",
     });
+    replyPersisted = true;
 
     logger.info(
       { contentLength: replyText.length, messageId: createdMessage.id },
@@ -913,6 +945,15 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
       },
       "chat_unhandled_error"
     );
+
+    // If a message row was created but the request didn't reach the durable
+    // COMPLETE write, mark it FAILED so the COMPLETE-only history filter
+    // treats it as a dead row immediately rather than waiting for the 60-min
+    // sweeper. Skip when replyPersisted is true to avoid downgrading a
+    // successful row when a post-save step (logger / response build) throws.
+    if (createdMessageId && !replyPersisted) {
+      await markMessageFailed(createdMessageId);
+    }
 
     const { set } = ctx;
     set.status = 500;

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -359,6 +359,346 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
     );
 
     // =========================================================================
+    // SSE STREAMING PATH (in-process, bypasses queue mode)
+    // Triggered when client sends Accept: text/event-stream header.
+    // Non-SSE requests fall through to the existing queue/JSON paths below.
+    // =========================================================================
+    const acceptsSSE = request.headers
+      .get("accept")
+      ?.includes("text/event-stream");
+
+    if (acceptsSSE) {
+      logger.info(
+        { messageId: createdMessage.id, conversationId },
+        "chat_using_sse_mode",
+      );
+
+      // Import SSE dependencies at function scope (dynamic for TDZ safety)
+      const { runChatAgent } = await import("../chat-agent/runner");
+      const { fileUploadAgent } = await import("../agents/fileUpload");
+      const { getPendingFileIds, getFileStatus } = await import(
+        "../services/files/status"
+      );
+      const { getFileProcessQueue } = await import(
+        "../services/queue/queues"
+      );
+      const {
+        getConversationState,
+        updateMessage,
+        updateConversationState,
+      } = await import("../db/operations");
+
+      const encoder = new TextEncoder();
+      const sseStartTime = Date.now();
+      let turnIndex = 0;
+      let streamStarted = false;
+      let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+      const stream = new ReadableStream({
+        async start(controller) {
+          // Helper: safe enqueue (swallows errors if client disconnected)
+          const send = (event: string, data: unknown) => {
+            try {
+              controller.enqueue(
+                encoder.encode(
+                  `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`,
+                ),
+              );
+            } catch {
+              // Controller closed (client disconnected). Keep running so DB save happens.
+            }
+          };
+
+          // SSE comment frame - ignored by the client parser but keeps the
+          // connection alive through proxies (nginx default idle timeout 60s,
+          // Vercel edge 30s, etc.). Critical for long silent periods:
+          // tool execution (literature_search 30s timeout), file processing
+          // (up to 2 min) can easily exceed proxy idle limits.
+          const sendHeartbeat = () => {
+            try {
+              controller.enqueue(
+                encoder.encode(`: heartbeat ${Date.now()}\n\n`),
+              );
+            } catch {
+              // Controller closed
+            }
+          };
+
+          const startHeartbeat = () => {
+            if (heartbeatTimer) return;
+            // 15s interval: well under nginx (60s), Vercel edge (30s), CDN limits
+            heartbeatTimer = setInterval(sendHeartbeat, 15_000);
+          };
+
+          const stopHeartbeat = () => {
+            if (heartbeatTimer) {
+              clearInterval(heartbeatTimer);
+              heartbeatTimer = null;
+            }
+          };
+
+          const safeClose = () => {
+            stopHeartbeat();
+            try {
+              controller.close();
+            } catch {
+              // Already closed
+            }
+          };
+
+          try {
+            // Send init FIRST so client knows the request was accepted and
+            // can render its streaming bubble immediately. Then start heartbeats
+            // to keep proxies alive during the silent file-wait period.
+            send("init", {
+              messageId: createdMessage.id,
+              conversationId,
+            });
+            startHeartbeat();
+
+            // === File handling: TWO paths, handle both ===
+            //
+            // Path A: raw files in FormData (legacy direct upload).
+            // Process synchronously, mutates conversation state with uploadedDatasets.
+            if (files.length > 0) {
+              const conversationStateForFiles: ConversationState = {
+                id: conversationStateRecord.id,
+                values: conversationStateRecord.values,
+              };
+              await fileUploadAgent({
+                conversationState: conversationStateForFiles,
+                files,
+                userId,
+              });
+              conversationStateRecord.values =
+                conversationStateForFiles.values;
+            }
+
+            // Path B: presigned S3 upload flow (usePresignedUpload.ts).
+            // Files uploaded directly to S3 BEFORE this request, processed
+            // async by file-process worker. Port the exact wait logic from
+            // chat.worker.ts:95-174 so SSE doesn't race with file processing.
+            // Without this, the agent runs before uploaded datasets are ready.
+            if (conversationStateRecord.id) {
+              const pendingFileIds = await getPendingFileIds(
+                conversationStateRecord.id,
+              );
+              if (pendingFileIds.length > 0) {
+                logger.info(
+                  { messageId: createdMessage.id, pendingFileIds },
+                  "chat_sse_waiting_for_file_processing",
+                );
+                // CRITICAL: getFileProcessQueue() returns null when
+                // USE_JOB_QUEUE=false (queues.ts:120). Must null-guard before
+                // calling .getJob() or we null-deref in in-process mode.
+                const fileProcessQueue = getFileProcessQueue();
+                const maxWaitMs = 120_000; // 2 min cap, matches worker
+                const pollIntervalMs = 500;
+                const startWait = Date.now();
+
+                for (const fileId of pendingFileIds) {
+                  while (Date.now() - startWait < maxWaitMs) {
+                    // Prefer file status check (always available, DB-backed).
+                    // Queue job state only consulted when the queue exists.
+                    const fileStatus = await getFileStatus(fileId);
+                    if (fileStatus?.status === "ready") break;
+                    if (fileStatus?.status === "error") {
+                      logger.warn(
+                        { messageId: createdMessage.id, fileId },
+                        "chat_sse_file_failed_continuing",
+                      );
+                      break;
+                    }
+
+                    // Secondary signal from BullMQ job state when queue exists
+                    if (fileProcessQueue) {
+                      const fileJob = await fileProcessQueue.getJob(fileId);
+                      const fileJobState = fileJob
+                        ? await fileJob.getState()
+                        : null;
+                      if (fileJobState === "completed" || !fileJob) break;
+                      if (fileJobState === "failed") {
+                        logger.warn(
+                          { messageId: createdMessage.id, fileId },
+                          "chat_sse_file_job_failed_continuing",
+                        );
+                        break;
+                      }
+                    }
+
+                    await new Promise((r) =>
+                      setTimeout(r, pollIntervalMs),
+                    );
+                  }
+                }
+
+                // Refresh conversation state to pick up uploadedDatasets
+                const fresh = await getConversationState(
+                  conversationStateRecord.id,
+                );
+                if (fresh) {
+                  conversationStateRecord.values = fresh.values;
+                }
+              }
+            }
+
+            const result = await runChatAgent({
+              conversationId,
+              message,
+              uploadedDatasets:
+                conversationStateRecord.values.uploadedDatasets,
+              loadHistory: true,
+              onTextDelta: (delta) => {
+                if (!streamStarted) {
+                  streamStarted = true;
+                  turnIndex++;
+                  send("stream_start", { turnIndex });
+                }
+                send("delta", { text: delta, turnIndex });
+              },
+              onStreamPause: async () => {
+                // Called by loop.ts AFTER finalMessage, BEFORE tool execution
+                if (streamStarted) {
+                  send("stream_end", {
+                    isFinal: false,
+                    turnIndex,
+                    reason: "paused",
+                  });
+                  streamStarted = false;
+                }
+              },
+              onToolResult: async (info) => {
+                // Mirror existing in-process path: update conversation state
+                if (!conversationStateRecord.id) return;
+                try {
+                  await updateConversationState(conversationStateRecord.id, {
+                    ...conversationStateRecord.values,
+                    agentProgress: {
+                      stage: `tool:${info.toolName}`,
+                      toolCallCount: info.toolCallCount,
+                      lastToolCallId: info.toolCallId,
+                      isError: info.result.isError ?? false,
+                    },
+                  });
+                } catch (err) {
+                  logger.warn(
+                    { error: err, toolName: info.toolName },
+                    "conversation_state_update_failed",
+                  );
+                }
+              },
+            });
+
+            // === Truncation guard ===
+            // Matches existing non-SSE path at chat.ts:568.
+            // Never persist a partial answer as success.
+            if (result.hitMaxTokens) {
+              if (streamStarted) {
+                send("stream_end", {
+                  isFinal: false,
+                  turnIndex,
+                  reason: "truncated",
+                });
+              }
+              send("error", {
+                reason: "truncated",
+                message:
+                  "Response was truncated. Please try a shorter question.",
+              });
+              safeClose();
+              logger.warn(
+                { messageId: createdMessage.id },
+                "chat_sse_truncated",
+              );
+              return;
+            }
+            if (!result.replyText) {
+              send("error", {
+                reason: "empty_reply",
+                message: "No response generated. Please try again.",
+              });
+              safeClose();
+              logger.warn(
+                { messageId: createdMessage.id },
+                "chat_sse_empty_reply",
+              );
+              return;
+            }
+
+            // === Persist to DB BEFORE sending done ===
+            // Contract: "done" means the message is durably saved. If DB save
+            // fails, we send "error" instead - client keeps user message visible.
+            const responseTime = Date.now() - sseStartTime;
+            await updateMessage(createdMessage.id, {
+              content: result.replyText,
+            });
+            await updateMessageResponseTime(createdMessage.id, responseTime);
+
+            // === Terminal success signals (only after durable write) ===
+            if (streamStarted) {
+              send("stream_end", {
+                isFinal: true,
+                turnIndex,
+                reason: "complete",
+              });
+            }
+            send("done", { messageId: createdMessage.id });
+            safeClose();
+
+            logger.info(
+              {
+                messageId: createdMessage.id,
+                conversationId,
+                toolCallCount: result.toolCallCount,
+                totalInputTokens: result.totalInputTokens,
+                totalOutputTokens: result.totalOutputTokens,
+                responseTime,
+                replyLength: result.replyText.length,
+                streaming: true,
+              },
+              "chat_sse_completed",
+            );
+          } catch (err) {
+            logger.error(
+              { error: err, messageId: createdMessage.id },
+              "chat_sse_error",
+            );
+            send("error", {
+              reason: "agent_error",
+              message:
+                err instanceof Error ? err.message : "Streaming failed",
+            });
+            safeClose();
+          }
+        },
+        cancel() {
+          // Client disconnected. Agent loop keeps running via the awaited
+          // runChatAgent call - DB save still happens. send() becomes no-op.
+          // Clear the heartbeat timer to prevent leak.
+          if (heartbeatTimer) {
+            clearInterval(heartbeatTimer);
+            heartbeatTimer = null;
+          }
+          logger.info(
+            { messageId: createdMessage.id },
+            "chat_sse_client_disconnected",
+          );
+        },
+      });
+
+      return new Response(stream, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+          // Disable nginx buffering - critical for real-time streaming
+          "X-Accel-Buffering": "no",
+        },
+      });
+    }
+
+    // =========================================================================
     // DUAL MODE: Check if job queue is enabled
     // =========================================================================
     const { isJobQueueEnabled } = await import("../services/queue/connection");

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -5,8 +5,8 @@ import { rateLimitMiddleware } from "../middleware/rateLimiter";
 import { ensureUserAndConversation, setupConversationData } from "../services/chat/setup";
 import {
   createMessageRecord,
+  markMessageComplete,
   markMessageFailed,
-  updateMessageResponseTime,
 } from "../services/chat/tools";
 import type { ConversationState, State } from "../types/core";
 import type { ElysiaRouteContext } from "../types/elysia";
@@ -190,9 +190,69 @@ async function chatRetryHandler(ctx: ElysiaRouteContext<{ jobId: string }>) {
     };
   }
 
+  // Hoisted so both the reset and the rollback path can share the client.
+  const { getServiceClient } = await import("../db/client");
+  const { getBullMQConnection } = await import("../services/queue/connection");
+  const { CHAT_RETRY_MARKER_TTL_SECONDS, chatRetryMarkerKey } = await import(
+    "../services/queue/retry-marker"
+  );
+  const supabase = getServiceClient();
+  const redis = getBullMQConnection();
+  const markerKey = chatRetryMarkerKey(jobId);
+
   try {
-    // Retry the job - moves it back to waiting state
-    await job.retry();
+    // Set the retry-in-progress marker BEFORE the PENDING reset so the
+    // sweeper can't race the reset → job.retry() window. Without this
+    // marker, the sweeper sees PENDING + BullMQ state still `failed`
+    // (we haven't called retry yet) and flips the row straight back to
+    // FAILED. TTL is the natural cleanup; once job.retry() succeeds the
+    // BullMQ state will be `waiting`/`active` which the sweeper already
+    // treats as alive, so an explicit clear isn't needed.
+    try {
+      await redis.set(markerKey, "1", "EX", CHAT_RETRY_MARKER_TTL_SECONDS);
+    } catch (markerErr) {
+      logger.error({ err: markerErr, jobId, userId }, "chat_retry_set_marker_failed");
+      set.status = 500;
+      return {
+        error: "Failed to coordinate retry; please try again",
+        ok: false,
+      };
+    }
+
+    // Reset the message row from FAILED back to PENDING before re-queueing
+    // the BullMQ job. The worker's markMessageComplete requires PENDING; if
+    // we skip this reset, a successful retry would leave the row FAILED
+    // while BullMQ marks the job completed and the success notification
+    // is silently suppressed by the early-exit on `updated === false`.
+    //
+    // This is the only sanctioned PENDING ← FAILED transition in the state
+    // machine. The terminal-state invariant still holds for natural flow;
+    // explicit user-initiated retry is the one allowed re-opening.
+    const { error: resetError } = await supabase
+      .from("messages")
+      .update({ status: "PENDING" })
+      .eq("id", jobId)
+      .eq("status", "FAILED");
+    if (resetError) {
+      logger.error({ error: resetError, jobId, userId }, "chat_retry_reset_message_status_failed");
+      set.status = 500;
+      return {
+        error: "Failed to reset message status for retry",
+        ok: false,
+      };
+    }
+
+    // Re-queue the BullMQ job. If this throws, roll the reset back so
+    // consumers don't see a stale "in-flight" row until the sweeper
+    // catches it. markMessageFailed's guard against downgrading COMPLETE
+    // makes this safe: in the only state we care about (PENDING), it
+    // flips to FAILED; in any other state it's a no-op.
+    try {
+      await job.retry();
+    } catch (retryErr) {
+      await markMessageFailed(jobId);
+      throw retryErr;
+    }
 
     logger.info(
       {
@@ -389,9 +449,7 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
       const { fileUploadAgent } = await import("../agents/fileUpload");
       const { getPendingFileIds, getFileStatus } = await import("../services/files/status");
       const { getFileProcessQueue } = await import("../services/queue/queues");
-      const { getConversationState, updateMessage, updateConversationState } = await import(
-        "../db/operations"
-      );
+      const { getConversationState, updateConversationState } = await import("../db/operations");
 
       const encoder = new TextEncoder();
       const sseStartTime = Date.now();
@@ -628,15 +686,27 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
             }
 
             // === Persist to DB BEFORE sending done ===
-            // Contract: "done" means the message is durably saved. If DB save
-            // fails, we send "error" instead - client keeps user message visible.
+            // Contract: "done" means the message is durably saved. The
+            // PENDING precondition (see markMessageComplete) means a row
+            // already moved to a terminal state surfaces as `error`.
             const responseTime = Date.now() - sseStartTime;
-            await updateMessage(createdMessage.id, {
+            const { updated } = await markMessageComplete(createdMessage.id, {
               content: result.replyText,
-              status: "COMPLETE",
+              response_time: responseTime,
             });
+            if (!updated) {
+              send("error", {
+                message: "Response failed to save. Please retry.",
+                reason: "agent_error",
+              });
+              safeClose();
+              logger.warn(
+                { messageId: createdMessage.id },
+                "chat_sse_complete_skipped_row_not_pending"
+              );
+              return;
+            }
             replyPersisted = true;
-            await updateMessageResponseTime(createdMessage.id, responseTime);
 
             // === Terminal success signals (only after durable write) ===
             if (streamStarted) {
@@ -894,20 +964,29 @@ export async function chatHandler(ctx: ElysiaRouteContext) {
     // Calculate response time
     const responseTime = Date.now() - startTime;
 
-    // Save the response to the message's content field
-    const { updateMessage } = await import("../db/operations");
-    await updateMessage(createdMessage.id, {
+    // Save the response to the message's content field. Guarded so a
+    // sweeper-flipped FAILED row isn't silently overwritten with COMPLETE.
+    const { updated } = await markMessageComplete(createdMessage.id, {
       content: replyText,
-      status: "COMPLETE",
+      response_time: responseTime,
     });
+    if (!updated) {
+      logger.warn(
+        { messageId: createdMessage.id },
+        "chat_in_process_complete_skipped_row_not_pending"
+      );
+      set.status = 500;
+      return {
+        error: "Response failed to save. Please retry.",
+        ok: false,
+      };
+    }
     replyPersisted = true;
 
     logger.info(
       { contentLength: replyText.length, messageId: createdMessage.id },
       "message_content_saved"
     );
-
-    await updateMessageResponseTime(createdMessage.id, responseTime);
 
     logger.info(
       {

--- a/src/routes/deep-research/__tests__/branch.test.ts
+++ b/src/routes/deep-research/__tests__/branch.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeBranchedMessage } from "../branch";
+
+describe("normalizeBranchedMessage", () => {
+  const branchedConversationId = "branch-conv-123";
+  const userId = "user-456";
+
+  test("rewrites conversation_id, user_id, and clears state_id", () => {
+    const source = {
+      content: "answer",
+      conversation_id: "source-conv",
+      created_at: "2026-04-28T00:00:00Z",
+      question: "user question",
+      source: "ui",
+      state_id: "state-789",
+      status: "COMPLETE",
+      user_id: "original-user",
+    };
+
+    const result = normalizeBranchedMessage(source, branchedConversationId, userId);
+
+    expect(result.conversation_id).toBe(branchedConversationId);
+    expect(result.user_id).toBe(userId);
+    expect(result.state_id).toBeNull();
+  });
+
+  test("preserves COMPLETE status unchanged", () => {
+    const source = { content: "ok", question: "q", status: "COMPLETE" };
+    const result = normalizeBranchedMessage(source, branchedConversationId, userId);
+    expect(result.status).toBe("COMPLETE");
+  });
+
+  test("preserves FAILED status unchanged", () => {
+    const source = { content: "", question: "q", status: "FAILED" };
+    const result = normalizeBranchedMessage(source, branchedConversationId, userId);
+    expect(result.status).toBe("FAILED");
+  });
+
+  test("normalizes PENDING source row to FAILED in the copy", () => {
+    const source = { content: "", question: "user asked something", status: "PENDING" };
+    const result = normalizeBranchedMessage(source, branchedConversationId, userId);
+    // PENDING in source means: either live in-flight, or a deep-research
+    // failure that never wrote FAILED. Either way the copy can't execute
+    // (state_id is nulled), so we mark it FAILED in the branch. The user's
+    // question is still preserved on the row.
+    expect(result.status).toBe("FAILED");
+    expect(result.question).toBe("user asked something");
+  });
+
+  test("falls back to source='ui' when source field is missing", () => {
+    const source = { content: "ok", question: "q", status: "COMPLETE" };
+    const result = normalizeBranchedMessage(source, branchedConversationId, userId);
+    expect(result.source).toBe("ui");
+  });
+
+  test("preserves explicit source field when present", () => {
+    const source = { content: "ok", question: "q", source: "api", status: "COMPLETE" };
+    const result = normalizeBranchedMessage(source, branchedConversationId, userId);
+    expect(result.source).toBe("api");
+  });
+});

--- a/src/routes/deep-research/branch.ts
+++ b/src/routes/deep-research/branch.ts
@@ -20,6 +20,7 @@ const COPY_MESSAGE_COLUMNS = [
   "clean_content",
   "citation_metadata",
   "response_time",
+  "status",
   "created_at",
 ] as const;
 
@@ -38,6 +39,37 @@ const COPY_STATE_KEYS = [
   "clarificationContext",
   "researchMode",
 ] as const;
+
+/**
+ * Normalize a source message row for insertion into the branched
+ * conversation.
+ *
+ * Branches are snapshots, not live continuations: once `state_id` is stripped
+ * the copied row can never be picked up by a worker in the branch. Any source
+ * row in PENDING status (whether genuinely in-flight or a deep-research
+ * failure that never wrote FAILED) is therefore non-executable in the branch
+ * and is normalized to FAILED at copy time.
+ *
+ * Trade-off: FAILED in branched conversations covers both "genuinely failed
+ * in source" and "unfinished at branch time and therefore non-completable
+ * in the branch." Acceptable because the branch's own status machine has
+ * no way to distinguish the two and the user's question is preserved either
+ * way.
+ */
+export function normalizeBranchedMessage(
+  row: Record<string, unknown>,
+  branchedConversationId: string,
+  userId: string
+): Record<string, unknown> {
+  return {
+    ...row,
+    conversation_id: branchedConversationId,
+    source: row.source ?? "ui",
+    state_id: null,
+    status: row.status === "PENDING" ? "FAILED" : row.status,
+    user_id: userId,
+  };
+}
 
 function toStateValues(rawValues: unknown): Record<string, unknown> {
   if (!rawValues) return {};
@@ -275,14 +307,8 @@ async function deepResearchBranchHandler(ctx: ElysiaRouteContext) {
     }
 
     if (sourceMessages && sourceMessages.length > 0) {
-      const copiedMessages = (sourceMessages as unknown as Record<string, unknown>[]).map(
-        (row) => ({
-          ...row,
-          conversation_id: branchedConversationId,
-          source: row.source ?? "ui",
-          state_id: null,
-          user_id: userId,
-        })
+      const copiedMessages = (sourceMessages as unknown as Record<string, unknown>[]).map((row) =>
+        normalizeBranchedMessage(row, branchedConversationId, userId)
       );
 
       const { error: copyMessagesError } = await supabase.from("messages").insert(copiedMessages);

--- a/src/routes/deep-research/start.ts
+++ b/src/routes/deep-research/start.ts
@@ -1761,6 +1761,7 @@ These molecular changes align with established longevity pathways (Converging nu
       await updateMessage(currentMessage.id, {
         content: replyResult.reply,
         response_time: iterationResponseTime, // Mark message as complete so UI displays it
+        status: "COMPLETE",
         summary: replyResult.summary,
       });
 

--- a/src/routes/deep-research/start.ts
+++ b/src/routes/deep-research/start.ts
@@ -17,7 +17,6 @@ import {
   getConversationState,
   getMessagesByConversation,
   updateConversationState,
-  updateMessage,
   updateState,
 } from "../../db/operations";
 
@@ -1802,14 +1801,23 @@ These molecular changes align with established longevity pathways (Converging nu
         nextPlan: conversationState.values.suggestedNextSteps || [],
       });
 
-      // Update the current message with the reply and mark as complete
+      // Update the current message with the reply. Sweeper exempts
+      // deep-research rows via the isDeepResearch flag so this is normally
+      // unguarded ground; the precondition (see markMessageComplete) is
+      // defensive against manual SQL flips or future callers.
       const iterationResponseTime = Date.now() - iterationStartTime;
-      await updateMessage(currentMessage.id, {
+      const { markMessageComplete } = await import("../../services/chat/tools");
+      const { updated } = await markMessageComplete(currentMessage.id, {
         content: replyResult.reply,
-        response_time: iterationResponseTime, // Mark message as complete so UI displays it
-        status: "COMPLETE",
+        response_time: iterationResponseTime,
         summary: replyResult.summary,
       });
+      if (!updated) {
+        logger.warn(
+          { iterationCount, messageId: currentMessage.id },
+          "deep_research_in_process_complete_skipped_row_not_pending"
+        );
+      }
 
       logger.info(
         {

--- a/src/routes/deep-research/start.ts
+++ b/src/routes/deep-research/start.ts
@@ -606,6 +606,19 @@ export async function deepResearchStartHandler(ctx: ElysiaRouteContext) {
     };
   }
 
+  // Mark the state row as deep-research at enqueue time so the message
+  // sweeper can distinguish queued deep-research jobs from chat orphans
+  // before the worker (which also sets this flag) ever runs. A queued job
+  // sitting in BullMQ backlog past the sweeper's threshold would otherwise
+  // get incorrectly swept. Strict — if this write fails the sweeper boundary
+  // is unsafe, so we surface the error instead of silently letting the job
+  // enqueue without a discriminator. The user retries; transient Supabase
+  // hiccups recover on the next request. Long-term fix is an atomic
+  // discriminator column on messages.
+  const stateValuesWithFlag = { ...stateRecord.values, isDeepResearch: true };
+  await updateState(stateRecord.id, stateValuesWithFlag);
+  stateRecord.values = stateValuesWithFlag;
+
   // =========================================================================
   // DUAL MODE: Check if job queue is enabled
   // =========================================================================
@@ -723,11 +736,28 @@ export async function deepResearchStartHandler(ctx: ElysiaRouteContext) {
         status: 202, // Accepted
       });
     } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "Unknown error";
+      // Status endpoint reads state.values.status to surface failure;
+      // without this update GET /api/deep-research/status/:messageId would
+      // keep reporting "processing" for a run that died before the worker
+      // ever owned it.
+      try {
+        await updateState(stateRecord.id, {
+          ...stateRecord.values,
+          error: errorMessage,
+          status: "failed",
+        });
+      } catch (stateErr) {
+        logger.warn(
+          { error: stateErr, stateId: stateRecord.id },
+          "deep_research_state_mark_failed_on_queue_error"
+        );
+      }
       if (runMarkedStarted) {
         try {
           await markRunFinished({
             conversationStateId: conversationStateRecord.id,
-            error: err instanceof Error ? err.message : "Unknown error",
+            error: errorMessage,
             result: "failed",
             rootMessageId: createdMessage.id,
             stateId: stateRecord.id,
@@ -774,11 +804,27 @@ export async function deepResearchStartHandler(ctx: ElysiaRouteContext) {
       logger.error({ err, messageId: createdMessage.id }, "deep_research_background_failed");
     });
   } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : "Unknown error";
+    // Synchronous failure before runDeepResearch's own try/catch fires.
+    // The async failure handler doesn't run here, so the status endpoint
+    // would otherwise keep reporting "processing" for a dead run.
+    try {
+      await updateState(stateRecord.id, {
+        ...stateRecord.values,
+        error: errorMessage,
+        status: "failed",
+      });
+    } catch (stateErr) {
+      logger.warn(
+        { error: stateErr, stateId: stateRecord.id },
+        "deep_research_state_mark_failed_on_in_process_start_error"
+      );
+    }
     if (runMarkedStarted) {
       try {
         await markRunFinished({
           conversationStateId: conversationStateRecord.id,
-          error: err instanceof Error ? err.message : "Unknown error",
+          error: errorMessage,
           result: "failed",
           rootMessageId: createdMessage.id,
           stateId: stateRecord.id,

--- a/src/services/chat/tools.ts
+++ b/src/services/chat/tools.ts
@@ -90,3 +90,44 @@ export async function markMessageFailed(messageId: string): Promise<void> {
     logger.warn({ err, messageId }, "failed_to_mark_message_failed");
   }
 }
+
+export type MarkMessageCompleteUpdates = {
+  content: string;
+  response_time?: number;
+  summary?: string;
+};
+
+/**
+ * Transition a message row to COMPLETE, but only if the row is still
+ * PENDING. Guards the inverse race that markMessageFailed protects against:
+ * if a sweeper or any other caller has already flipped the row to FAILED,
+ * the COMPLETE write must not silently overwrite — FAILED is terminal.
+ *
+ * Returns `{ updated: false }` when the row was no longer PENDING. Callers
+ * MUST honor that signal: do not emit success notifications, do not claim
+ * the reply is durable, and prefer surfacing an error to the user. The
+ * agent's reply text is lost in that case, which is the correct trade-off
+ * because the alternative is silent state-machine corruption.
+ */
+export async function markMessageComplete(
+  messageId: string,
+  updates: MarkMessageCompleteUpdates
+): Promise<{ updated: boolean }> {
+  const { getServiceClient } = await import("../../db/client");
+  const supabase = getServiceClient();
+  const { data, error } = await supabase
+    .from("messages")
+    .update({ ...updates, status: "COMPLETE" })
+    .eq("id", messageId)
+    .eq("status", "PENDING")
+    .select("id");
+  if (error) {
+    logger.error({ err: error, messageId }, "mark_message_complete_query_failed");
+    throw error;
+  }
+  const updated = (data?.length ?? 0) > 0;
+  if (!updated) {
+    logger.warn({ messageId }, "mark_message_complete_skipped_row_not_pending");
+  }
+  return { updated };
+}

--- a/src/services/chat/tools.ts
+++ b/src/services/chat/tools.ts
@@ -67,3 +67,26 @@ export async function updateMessageResponseTime(
     if (logger) logger.error({ err }, "failed_to_update_response_time");
   }
 }
+
+/**
+ * Best-effort transition of a message row to FAILED. Guarded so callers
+ * can't accidentally downgrade a COMPLETE row — the UPDATE only matches
+ * rows that aren't already terminal-COMPLETE. Never throws; if the UPDATE
+ * itself fails, the periodic sweeper catches stale PENDING rows later.
+ */
+export async function markMessageFailed(messageId: string): Promise<void> {
+  try {
+    const { getServiceClient } = await import("../../db/client");
+    const supabase = getServiceClient();
+    const { error } = await supabase
+      .from("messages")
+      .update({ status: "FAILED" })
+      .eq("id", messageId)
+      .neq("status", "COMPLETE");
+    if (error) {
+      logger.warn({ err: error, messageId }, "failed_to_mark_message_failed");
+    }
+  } catch (err) {
+    logger.warn({ err, messageId }, "failed_to_mark_message_failed");
+  }
+}

--- a/src/services/queue/queues.ts
+++ b/src/services/queue/queues.ts
@@ -6,6 +6,7 @@
  */
 
 import { Queue } from "bullmq";
+import logger from "../../utils/logger";
 import { getBullMQConnection, isJobQueueEnabled } from "./connection";
 import type {
   ChatJobData,
@@ -14,16 +15,19 @@ import type {
   DeepResearchJobResult,
   FileProcessJobData,
   FileProcessJobResult,
+  MessageSweepJobData,
+  MessageSweepJobResult,
   PaperGenerationJobData,
   PaperGenerationJobResult,
 } from "./types";
-import logger from "../../utils/logger";
 
 // Queue instances (lazy initialized)
 let chatQueueInstance: Queue<ChatJobData, ChatJobResult> | null = null;
 let deepResearchQueueInstance: Queue<DeepResearchJobData, DeepResearchJobResult> | null = null;
 let fileProcessQueueInstance: Queue<FileProcessJobData, FileProcessJobResult> | null = null;
-let paperGenerationQueueInstance: Queue<PaperGenerationJobData, PaperGenerationJobResult> | null = null;
+let paperGenerationQueueInstance: Queue<PaperGenerationJobData, PaperGenerationJobResult> | null =
+  null;
+let messageSweeperQueueInstance: Queue<MessageSweepJobData, MessageSweepJobResult> | null = null;
 
 /**
  * Get or create the chat queue
@@ -45,8 +49,8 @@ export function getChatQueue(): Queue<ChatJobData, ChatJobResult> {
         // Retry configuration
         attempts: 3, // Retry up to 3 times on failure
         backoff: {
-          type: "exponential", // 1s, 2s, 4s delays
           delay: 1000,
+          type: "exponential", // 1s, 2s, 4s delays
         },
         // Timeout - chat should complete within 3 minutes
         // timeout: 180000, // 3 minutes hard limit - DISABLED for now, using worker lockDuration instead
@@ -81,27 +85,30 @@ export function getDeepResearchQueue(): Queue<DeepResearchJobData, DeepResearchJ
   }
 
   if (!deepResearchQueueInstance) {
-    deepResearchQueueInstance = new Queue<DeepResearchJobData, DeepResearchJobResult>("deep-research", {
-      connection: getBullMQConnection(),
-      defaultJobOptions: {
-        // Retry configuration (fewer retries for long jobs)
-        attempts: 2, // Retry up to 2 times
-        backoff: {
-          type: "exponential", // 5s, 10s delays
-          delay: 5000,
+    deepResearchQueueInstance = new Queue<DeepResearchJobData, DeepResearchJobResult>(
+      "deep-research",
+      {
+        connection: getBullMQConnection(),
+        defaultJobOptions: {
+          // Retry configuration (fewer retries for long jobs)
+          attempts: 2, // Retry up to 2 times
+          backoff: {
+            delay: 5000,
+            type: "exponential", // 5s, 10s delays
+          },
+          // NO TIMEOUT - deep research can take 20-30+ minutes
+          // timeout: undefined,
+          // Job cleanup
+          removeOnComplete: {
+            age: 86400, // Keep for 24 hours
+            count: 500,
+          },
+          removeOnFail: {
+            age: 604800, // Keep failed for 7 days
+          },
         },
-        // NO TIMEOUT - deep research can take 20-30+ minutes
-        // timeout: undefined,
-        // Job cleanup
-        removeOnComplete: {
-          age: 86400, // Keep for 24 hours
-          count: 500,
-        },
-        removeOnFail: {
-          age: 604800, // Keep failed for 7 days
-        },
-      },
-    });
+      }
+    );
 
     logger.info({ queue: "deep-research" }, "deep_research_queue_initialized");
   }
@@ -128,8 +135,8 @@ export function getFileProcessQueue(): Queue<FileProcessJobData, FileProcessJobR
       defaultJobOptions: {
         attempts: 3,
         backoff: {
-          type: "exponential",
           delay: 1000,
+          type: "exponential",
         },
         removeOnComplete: {
           age: 3600, // Keep for 1 hour
@@ -161,22 +168,25 @@ export function getPaperGenerationQueue(): Queue<PaperGenerationJobData, PaperGe
   }
 
   if (!paperGenerationQueueInstance) {
-    paperGenerationQueueInstance = new Queue<PaperGenerationJobData, PaperGenerationJobResult>("paper-generation", {
-      connection: getBullMQConnection(),
-      defaultJobOptions: {
-        // NO RETRY - paper gen has internal fallback strategies
-        attempts: 1,
-        // NO TIMEOUT - let it run as long as needed
-        // Job cleanup
-        removeOnComplete: {
-          age: 86400, // Keep for 24 hours
-          count: 500,
+    paperGenerationQueueInstance = new Queue<PaperGenerationJobData, PaperGenerationJobResult>(
+      "paper-generation",
+      {
+        connection: getBullMQConnection(),
+        defaultJobOptions: {
+          // NO RETRY - paper gen has internal fallback strategies
+          attempts: 1,
+          // NO TIMEOUT - let it run as long as needed
+          // Job cleanup
+          removeOnComplete: {
+            age: 86400, // Keep for 24 hours
+            count: 500,
+          },
+          removeOnFail: {
+            age: 604800, // Keep failed for 7 days
+          },
         },
-        removeOnFail: {
-          age: 604800, // Keep failed for 7 days
-        },
-      },
-    });
+      }
+    );
 
     logger.info({ queue: "paper-generation" }, "paper_generation_queue_initialized");
   }
@@ -185,21 +195,59 @@ export function getPaperGenerationQueue(): Queue<PaperGenerationJobData, PaperGe
 }
 
 /**
+ * Get or create the message sweeper queue.
+ *
+ * Single-attempt jobs - if a sweep fails, the next scheduled run picks up
+ * the same stale rows.
+ */
+export function getMessageSweeperQueue(): Queue<MessageSweepJobData, MessageSweepJobResult> | null {
+  if (!isJobQueueEnabled()) {
+    return null;
+  }
+
+  if (!messageSweeperQueueInstance) {
+    messageSweeperQueueInstance = new Queue<MessageSweepJobData, MessageSweepJobResult>(
+      "message-sweeper",
+      {
+        connection: getBullMQConnection(),
+        defaultJobOptions: {
+          attempts: 1,
+          removeOnComplete: {
+            age: 86400, // Keep for 24 hours so we can audit how often the sweeper finds orphans
+            count: 200,
+          },
+          removeOnFail: {
+            age: 604800, // Keep failures for 7 days for debugging
+          },
+        },
+      }
+    );
+
+    logger.info({ queue: "message-sweeper" }, "message_sweeper_queue_initialized");
+  }
+
+  return messageSweeperQueueInstance;
+}
+
+/**
  * Close all queue instances (for graceful shutdown)
  */
 export async function closeQueues(): Promise<void> {
-  const queues = [chatQueueInstance, deepResearchQueueInstance, fileProcessQueueInstance, paperGenerationQueueInstance];
+  const queues = [
+    chatQueueInstance,
+    deepResearchQueueInstance,
+    fileProcessQueueInstance,
+    paperGenerationQueueInstance,
+    messageSweeperQueueInstance,
+  ];
 
-  await Promise.all(
-    queues
-      .filter((q): q is Queue => q !== null)
-      .map((q) => q.close()),
-  );
+  await Promise.all(queues.filter((q): q is Queue => q !== null).map((q) => q.close()));
 
   chatQueueInstance = null;
   deepResearchQueueInstance = null;
   fileProcessQueueInstance = null;
   paperGenerationQueueInstance = null;
+  messageSweeperQueueInstance = null;
 
   logger.info("queues_closed");
 }

--- a/src/services/queue/retry-marker.ts
+++ b/src/services/queue/retry-marker.ts
@@ -1,0 +1,23 @@
+/**
+ * Retry-in-progress marker shared between the manual chat retry endpoint
+ * and the message sweeper.
+ *
+ * The retry endpoint must reset the message row from FAILED to PENDING
+ * before calling `job.retry()`, otherwise the worker's markMessageComplete
+ * would no-op against a FAILED row. Without coordination, the sweeper can
+ * race that reset: it sees PENDING + a non-alive BullMQ state and flips
+ * the row straight back to FAILED while the retry is in flight.
+ *
+ * The retry endpoint sets this marker in Redis before the reset; the
+ * sweeper treats its presence as "alive" and skips the candidate. TTL is
+ * the natural cleanup so we don't need an explicit clear on the success
+ * path (BullMQ state will already be `waiting`/`active` by then, which
+ * the sweeper already treats as alive).
+ */
+const RETRY_IN_PROGRESS_KEY_PREFIX = "chat-retry-in-progress:";
+
+export const CHAT_RETRY_MARKER_TTL_SECONDS = 60;
+
+export function chatRetryMarkerKey(messageId: string): string {
+  return `${RETRY_IN_PROGRESS_KEY_PREFIX}${messageId}`;
+}

--- a/src/services/queue/types.ts
+++ b/src/services/queue/types.ts
@@ -144,6 +144,21 @@ export interface PaperGenerationJobResult {
 }
 
 /**
+ * Job data for the periodic message-orphan sweeper.
+ * No payload — the sweeper computes its own cutoff timestamp at run time.
+ */
+export type MessageSweepJobData = Record<string, never>;
+
+/**
+ * Result returned by the message sweeper after each periodic run.
+ */
+export interface MessageSweepJobResult {
+  flippedCount: number;
+  cutoffIso: string;
+  durationMs: number;
+}
+
+/**
  * Paper generation progress stages
  */
 export type PaperGenerationStage =

--- a/src/services/queue/workers/chat.worker.ts
+++ b/src/services/queue/workers/chat.worker.ts
@@ -330,27 +330,31 @@ async function processChatJob(job: Job<ChatJobData, ChatJobResult>): Promise<Cha
     );
 
     // Save reply to message
-    await updateMessage(messageId, { content: replyText });
-
-    // Calculate and update response time
+    await updateMessage(messageId, { content: replyText, status: "COMPLETE" });
     const responseTime = Date.now() - startTime;
-    await updateMessageResponseTime(messageId, responseTime);
 
-    // Notify: Message updated (content is now available)
-    await notifyMessageUpdated(job.id!, conversationId, messageId);
-
-    logger.info(
-      {
-        jobId: job.id,
-        messageId,
-        responseTime,
-        responseTimeSec: (responseTime / 1000).toFixed(2),
-      },
-      "chat_job_completed"
-    );
-
-    // Notify: Job completed
-    await notifyJobCompleted(job.id!, conversationId, messageId);
+    // Best-effort: response-time write and pub/sub notifications. Reply is
+    // already durably saved with status=COMPLETE, so failures here must not
+    // bubble to the outer catch and downgrade the row to FAILED.
+    try {
+      await updateMessageResponseTime(messageId, responseTime);
+      await notifyMessageUpdated(job.id!, conversationId, messageId);
+      logger.info(
+        {
+          jobId: job.id,
+          messageId,
+          responseTime,
+          responseTimeSec: (responseTime / 1000).toFixed(2),
+        },
+        "chat_job_completed"
+      );
+      await notifyJobCompleted(job.id!, conversationId, messageId);
+    } catch (notifyErr) {
+      logger.warn(
+        { error: notifyErr, jobId: job.id, messageId },
+        "chat_job_post_reply_notify_failed"
+      );
+    }
 
     return {
       responseTime,
@@ -371,7 +375,11 @@ async function processChatJob(job: Job<ChatJobData, ChatJobResult>): Promise<Cha
     // Notify: Job failed (on final attempt, or immediately for unrecoverable errors)
     const { UnrecoverableError } = await import("bullmq");
     if (job.attemptsMade + 1 >= (job.opts.attempts || 3) || error instanceof UnrecoverableError) {
-      await notifyJobFailed(job.id!, conversationId, messageId);
+      const { markMessageFailed } = await import("../../chat/tools");
+      await Promise.all([
+        notifyJobFailed(job.id!, conversationId, messageId),
+        markMessageFailed(messageId),
+      ]);
     }
 
     // Re-throw to trigger retry (if attempts remaining)
@@ -456,7 +464,7 @@ async function processWithAgentLoop(
   // Critical: persist the reply first. If this fails, retrying is correct
   // because the LLM result would otherwise be lost.
   const responseTime = Date.now() - startTime;
-  await updateMessage(messageId, { content: result.replyText });
+  await updateMessage(messageId, { content: result.replyText, status: "COMPLETE" });
   await updateMessageResponseTime(messageId, responseTime);
 
   // Best-effort: progress updates and notifications. Reply is already saved,

--- a/src/services/queue/workers/chat.worker.ts
+++ b/src/services/queue/workers/chat.worker.ts
@@ -21,6 +21,24 @@ import {
 import type { ChatJobData, ChatJobResult, JobProgress } from "../types";
 
 /**
+ * Throws UnrecoverableError when markMessageComplete reported the row was
+ * no longer PENDING. Keeping the BullMQ job in `failed` state preserves
+ * retryability through `/api/chat/retry/:jobId`; returning success would
+ * mark the job `completed` and dead-end the user.
+ */
+async function failJobIfRowNoLongerPending(
+  updated: boolean,
+  jobId: string | undefined,
+  messageId: string,
+  logKey: string
+): Promise<void> {
+  if (updated) return;
+  const { UnrecoverableError } = await import("bullmq");
+  logger.warn({ jobId, messageId }, logKey);
+  throw new UnrecoverableError("Message row is no longer in PENDING state; cannot persist reply");
+}
+
+/**
  * Process a chat job
  * This is the core chat processing logic extracted from chatHandler
  */
@@ -48,9 +66,9 @@ async function processChatJob(job: Job<ChatJobData, ChatJobResult>): Promise<Cha
 
   try {
     // Import required modules
-    const { getMessage, getState, getConversationState, updateConversationState, updateMessage } =
-      await import("../../../db/operations");
-    const { updateMessageResponseTime } = await import("../../chat/tools");
+    const { getMessage, getState, getConversationState, updateConversationState } = await import(
+      "../../../db/operations"
+    );
 
     // Get message record (already created by route handler)
     const messageRecord = await getMessage(messageId);
@@ -329,15 +347,25 @@ async function processChatJob(job: Job<ChatJobData, ChatJobResult>): Promise<Cha
       }
     );
 
-    // Save reply to message
-    await updateMessage(messageId, { content: replyText, status: "COMPLETE" });
+    // Save reply to message. Guarded by markMessageComplete's PENDING
+    // precondition; see its JSDoc for the FAILED-is-terminal contract.
     const responseTime = Date.now() - startTime;
+    const { markMessageComplete } = await import("../../chat/tools");
+    const { updated } = await markMessageComplete(messageId, {
+      content: replyText,
+      response_time: responseTime,
+    });
+    await failJobIfRowNoLongerPending(
+      updated,
+      job.id,
+      messageId,
+      "chat_worker_legacy_complete_skipped_row_not_pending"
+    );
 
-    // Best-effort: response-time write and pub/sub notifications. Reply is
-    // already durably saved with status=COMPLETE, so failures here must not
-    // bubble to the outer catch and downgrade the row to FAILED.
+    // Best-effort: pub/sub notifications. Reply is already durably saved with
+    // status=COMPLETE, so failures here must not bubble to the outer catch
+    // and downgrade the row to FAILED.
     try {
-      await updateMessageResponseTime(messageId, responseTime);
       await notifyMessageUpdated(job.id!, conversationId, messageId);
       logger.info(
         {
@@ -412,8 +440,6 @@ async function processWithAgentLoop(
   }
 
   const { runChatAgent } = await import("../../../chat-agent/runner");
-  const { updateMessage } = await import("../../../db/operations");
-  const { updateMessageResponseTime } = await import("../../chat/tools");
 
   let literatureEmitted = false;
 
@@ -461,11 +487,20 @@ async function processWithAgentLoop(
     throw new UnrecoverableError("Agent loop response truncated (max_tokens)");
   }
 
-  // Critical: persist the reply first. If this fails, retrying is correct
-  // because the LLM result would otherwise be lost.
+  // Persist the reply with markMessageComplete's PENDING precondition;
+  // see its JSDoc for the FAILED-is-terminal contract.
   const responseTime = Date.now() - startTime;
-  await updateMessage(messageId, { content: result.replyText, status: "COMPLETE" });
-  await updateMessageResponseTime(messageId, responseTime);
+  const { markMessageComplete } = await import("../../chat/tools");
+  const { updated } = await markMessageComplete(messageId, {
+    content: result.replyText,
+    response_time: responseTime,
+  });
+  await failJobIfRowNoLongerPending(
+    updated,
+    job.id,
+    messageId,
+    "chat_worker_agent_loop_complete_skipped_row_not_pending"
+  );
 
   // Best-effort: progress updates and notifications. Reply is already saved,
   // so failures here should not trigger a retry or mark the job as failed.

--- a/src/services/queue/workers/deep-research.worker.ts
+++ b/src/services/queue/workers/deep-research.worker.ts
@@ -225,8 +225,9 @@ async function processDeepResearchJob(
     }
 
     // Import required modules
-    const { getMessage, getState, getConversationState, updateConversationState, updateMessage } =
-      await import("../../../db/operations");
+    const { getMessage, getState, getConversationState, updateConversationState } = await import(
+      "../../../db/operations"
+    );
     updateConversationStateRef = updateConversationState;
 
     // Get message record
@@ -1019,14 +1020,23 @@ async function processDeepResearchJob(
       );
     }
 
-    // Update the current message with the reply and mark as complete
+    // Update the current message with the reply. Sweeper exempts
+    // deep-research rows via the isDeepResearch flag so this is normally
+    // unguarded ground; the precondition (see markMessageComplete) is
+    // defensive against manual SQL flips or future callers.
     const iterationResponseTime = Date.now() - startTime;
-    await updateMessage(currentMessage.id, {
+    const { markMessageComplete } = await import("../../chat/tools");
+    const { updated } = await markMessageComplete(currentMessage.id, {
       content: replyResult.reply,
-      response_time: iterationResponseTime, // Mark message as complete so UI displays it
-      status: "COMPLETE",
+      response_time: iterationResponseTime,
       summary: replyResult.summary,
     });
+    if (!updated) {
+      logger.warn(
+        { iterationNumber, jobId: job.id, messageId: currentMessage.id },
+        "deep_research_iteration_complete_skipped_row_not_pending"
+      );
+    }
 
     logger.info(
       {

--- a/src/services/queue/workers/deep-research.worker.ts
+++ b/src/services/queue/workers/deep-research.worker.ts
@@ -1024,6 +1024,7 @@ async function processDeepResearchJob(
     await updateMessage(currentMessage.id, {
       content: replyResult.reply,
       response_time: iterationResponseTime, // Mark message as complete so UI displays it
+      status: "COMPLETE",
       summary: replyResult.summary,
     });
 

--- a/src/services/queue/workers/message-sweeper.worker.ts
+++ b/src/services/queue/workers/message-sweeper.worker.ts
@@ -1,0 +1,163 @@
+/**
+ * Message Sweeper Worker
+ *
+ * Periodic background job that flips stale PENDING message rows to FAILED
+ * after a backend crash. Streaming chat bypasses BullMQ retries, so without
+ * this sweeper a process death mid-stream leaves the row PENDING forever.
+ */
+
+import { type Job, Worker } from "bullmq";
+import logger from "../../../utils/logger";
+import { getBullMQConnection } from "../connection";
+import type { MessageSweepJobData, MessageSweepJobResult } from "../types";
+
+// Sized for chat-mode orphan recovery only. Chat replies finish in 10-30s,
+// so any PENDING row past 20min is definitively dead from a process-death
+// case (deploy / OOM / segfault) — chat catches mark FAILED immediately on
+// recoverable errors, this is the safety net. Deep-research iterations
+// (Steering ~20min, Smart ~60min, Autonomous up to ~8h) sit comfortably
+// above this threshold; BullMQ retries are the recovery path for those,
+// not the sweeper.
+const ORPHAN_AGE_MS = 20 * 60 * 1000;
+const SWEEPER_INTERVAL_MS = 5 * 60 * 1000;
+const SCHEDULER_ID = "message-sweeper";
+
+/**
+ * Shared core sweep operation. Used by both the BullMQ worker (queue mode)
+ * and the in-process setInterval sweeper (default deployment mode).
+ *
+ * Two-step to keep the chat-only scope explicit: first SELECT eligible
+ * orphan rows joined to their state, then exclude rows whose state has
+ * `values.isDeepResearch === true`. Deep-research jobs use BullMQ retries
+ * for recovery and routinely sit PENDING for tens of minutes to hours;
+ * including them here would clobber legitimate runs.
+ *
+ * Transitional design — long-term, a dedicated discriminator column on
+ * `messages` would make this a single UPDATE without the JOIN.
+ */
+async function runSweep(jobId?: string | number): Promise<MessageSweepJobResult> {
+  const start = Date.now();
+  const cutoffIso = new Date(start - ORPHAN_AGE_MS).toISOString();
+
+  const { getServiceClient } = await import("../../../db/client");
+  const supabase = getServiceClient();
+
+  const { data: candidates, error: selectError } = await supabase
+    .from("messages")
+    .select("id, state:states(values)")
+    .eq("status", "PENDING")
+    .lt("created_at", cutoffIso);
+
+  if (selectError) {
+    logger.error({ cutoffIso, error: selectError.message, jobId }, "message_sweeper_query_failed");
+    throw selectError;
+  }
+
+  const chatOrphanIds = (candidates ?? [])
+    .filter((row) => {
+      const state = row.state as { values?: { isDeepResearch?: boolean } } | null;
+      return state?.values?.isDeepResearch !== true;
+    })
+    .map((row) => row.id as string);
+
+  let flippedCount = 0;
+  if (chatOrphanIds.length > 0) {
+    const { data: flipped, error: updateError } = await supabase
+      .from("messages")
+      .update({ status: "FAILED" })
+      .in("id", chatOrphanIds)
+      .eq("status", "PENDING")
+      .select("id");
+
+    if (updateError) {
+      logger.error(
+        { cutoffIso, error: updateError.message, jobId },
+        "message_sweeper_update_failed"
+      );
+      throw updateError;
+    }
+    flippedCount = flipped?.length ?? 0;
+  }
+
+  const durationMs = Date.now() - start;
+
+  if (flippedCount > 0) {
+    logger.warn({ cutoffIso, durationMs, flippedCount, jobId }, "message_sweeper_flipped_orphans");
+  }
+
+  return { cutoffIso, durationMs, flippedCount };
+}
+
+async function processSweep(
+  job: Job<MessageSweepJobData, MessageSweepJobResult>
+): Promise<MessageSweepJobResult> {
+  return runSweep(job.id);
+}
+
+/**
+ * Register the repeatable sweep job. Safe to call multiple times — BullMQ
+ * dedupes by scheduler ID.
+ */
+export async function registerMessageSweeperSchedule(): Promise<void> {
+  const { getMessageSweeperQueue } = await import("../queues");
+  const queue = getMessageSweeperQueue();
+  if (!queue) {
+    logger.info("message_sweeper_schedule_skipped_queue_disabled");
+    return;
+  }
+
+  await queue.upsertJobScheduler(
+    SCHEDULER_ID,
+    { every: SWEEPER_INTERVAL_MS },
+    {
+      data: {},
+      name: "sweep",
+      opts: {
+        removeOnComplete: { age: 86400, count: 200 },
+        removeOnFail: { age: 604800 },
+      },
+    }
+  );
+
+  logger.info(
+    { intervalMs: SWEEPER_INTERVAL_MS, schedulerId: SCHEDULER_ID },
+    "message_sweeper_schedule_registered"
+  );
+}
+
+export function startMessageSweeperWorker(): Worker<MessageSweepJobData, MessageSweepJobResult> {
+  const worker = new Worker<MessageSweepJobData, MessageSweepJobResult>(
+    "message-sweeper",
+    processSweep,
+    {
+      concurrency: 1,
+      connection: getBullMQConnection(),
+    }
+  );
+
+  worker.on("failed", (job, error) => {
+    logger.error({ error: error.message, jobId: job?.id }, "message_sweeper_job_failed");
+  });
+
+  logger.info("message_sweeper_worker_started");
+  return worker;
+}
+
+/**
+ * In-process sweeper for deployments running with USE_JOB_QUEUE=false.
+ * Uses a plain setInterval on the API server process — no Redis/BullMQ
+ * dependency. The chat-agent SSE path is in-process in this mode, so the
+ * API server is the natural home for orphan cleanup. Returns the timer so
+ * the caller can clear it on graceful shutdown.
+ */
+export function startInProcessMessageSweeper(): NodeJS.Timeout {
+  logger.info(
+    { intervalMs: SWEEPER_INTERVAL_MS, orphanAgeMs: ORPHAN_AGE_MS },
+    "in_process_message_sweeper_started"
+  );
+  return setInterval(() => {
+    runSweep().catch((err) => {
+      logger.error({ err }, "in_process_message_sweeper_failed");
+    });
+  }, SWEEPER_INTERVAL_MS);
+}

--- a/src/services/queue/workers/message-sweeper.worker.ts
+++ b/src/services/queue/workers/message-sweeper.worker.ts
@@ -8,8 +8,15 @@
 
 import { type Job, Worker } from "bullmq";
 import logger from "../../../utils/logger";
-import { getBullMQConnection } from "../connection";
+import { getBullMQConnection, isJobQueueEnabled } from "../connection";
 import type { MessageSweepJobData, MessageSweepJobResult } from "../types";
+
+// BullMQ job states that indicate the worker hasn't picked up (or is still
+// running) the job. A row whose chat job is in any of these states is NOT
+// an orphan; the sweeper must leave it alone, otherwise the worker will
+// later overwrite the FAILED row with COMPLETE and silently violate the
+// terminal-state contract.
+const ALIVE_BULLMQ_STATES = new Set(["waiting", "delayed", "active", "paused"]);
 
 // Sized for chat-mode orphan recovery only. Chat replies finish in 10-30s,
 // so any PENDING row past 20min is definitively dead from a process-death
@@ -53,12 +60,83 @@ async function runSweep(jobId?: string | number): Promise<MessageSweepJobResult>
     throw selectError;
   }
 
-  const chatOrphanIds = (candidates ?? [])
+  let chatOrphanIds = (candidates ?? [])
     .filter((row) => {
       const state = row.state as { values?: { isDeepResearch?: boolean } } | null;
       return state?.values?.isDeepResearch !== true;
     })
     .map((row) => row.id as string);
+
+  // In queue mode, additionally skip rows whose chat BullMQ job is still
+  // alive (waiting / delayed / active / paused). The job hasn't been picked
+  // up by a worker yet — this is a slow worker or an offline worker, not a
+  // dead orphan. Flipping the row here would let the worker later overwrite
+  // FAILED with COMPLETE, breaking the terminal-state guarantee.
+  //
+  // Also check for the chat-retry-in-progress marker. The retry endpoint
+  // sets that marker between the PENDING reset and `job.retry()`, a window
+  // where BullMQ state is still `failed` (not in the alive set) but flipping
+  // the row would defeat the in-flight retry. The marker closes that race.
+  if (isJobQueueEnabled() && chatOrphanIds.length > 0) {
+    try {
+      const { getChatQueue } = await import("../queues");
+      const { getBullMQConnection } = await import("../connection");
+      const { chatRetryMarkerKey } = await import("../retry-marker");
+      const chatQueue = getChatQueue();
+      const redis = getBullMQConnection();
+
+      // Batch the marker existence check into one Redis round-trip via
+      // pipelining. With N candidates this collapses N EXISTS calls into
+      // one network hop; in steady state most calls return 0 anyway.
+      const markerKeys = chatOrphanIds.map((id) => chatRetryMarkerKey(id));
+      let markerByIndex = new Array<boolean>(chatOrphanIds.length).fill(false);
+      try {
+        const pipeline = redis.pipeline();
+        for (const key of markerKeys) pipeline.exists(key);
+        const results = await pipeline.exec();
+        if (results) {
+          markerByIndex = results.map(([_err, value]) => Number(value) > 0);
+        }
+      } catch (markerErr) {
+        logger.warn({ err: markerErr }, "message_sweeper_retry_marker_pipeline_failed");
+        // Treat all as alive on pipeline failure — safer than flipping rows
+        // we couldn't verify against the marker.
+        markerByIndex = markerByIndex.map(() => true);
+      }
+
+      // BullMQ state checks for the remaining candidates run in parallel.
+      // Per-candidate failure falls open (treat as alive) — safer than
+      // flipping a live row to FAILED.
+      const stateChecks = chatOrphanIds.map(async (id, i) => {
+        if (markerByIndex[i]) return { alive: true, id };
+        try {
+          const queueJob = await chatQueue.getJob(id);
+          if (!queueJob) return { alive: false, id };
+          const state = await queueJob.getState();
+          return { alive: ALIVE_BULLMQ_STATES.has(state), id };
+        } catch (jobErr) {
+          logger.warn({ err: jobErr, messageId: id }, "message_sweeper_job_state_check_failed");
+          return { alive: true, id };
+        }
+      });
+      const results = await Promise.all(stateChecks);
+      const liveJobIds = new Set(results.filter((r) => r.alive).map((r) => r.id));
+
+      if (liveJobIds.size > 0) {
+        logger.info(
+          { skippedCount: liveJobIds.size, totalCandidates: chatOrphanIds.length },
+          "message_sweeper_skipped_live_jobs"
+        );
+      }
+      chatOrphanIds = chatOrphanIds.filter((id) => !liveJobIds.has(id));
+    } catch (queueErr) {
+      // If we can't get the queue at all (Redis down, etc.), skip the whole
+      // sweep round. Better to leak rows for one interval than to flip live
+      // ones with no visibility into worker state.
+      logger.error({ err: queueErr, jobId }, "message_sweeper_queue_check_failed_skipping_sweep");
+      return { cutoffIso, durationMs: Date.now() - start, flippedCount: 0 };
+    }
+  }
 
   let flippedCount = 0;
   if (chatOrphanIds.length > 0) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -11,11 +11,15 @@
 // Must be first - polyfills for pdf-parse/pdfjs-dist
 import "./utils/canvas-polyfill";
 
+import { closeConnections } from "./services/queue/connection";
 import { startChatWorker } from "./services/queue/workers/chat.worker";
 import { startDeepResearchWorker } from "./services/queue/workers/deep-research.worker";
 import { createFileProcessWorker } from "./services/queue/workers/file-process.worker";
+import {
+  registerMessageSweeperSchedule,
+  startMessageSweeperWorker,
+} from "./services/queue/workers/message-sweeper.worker";
 import { startPaperGenerationWorker } from "./services/queue/workers/paper-generation.worker";
-import { closeConnections } from "./services/queue/connection";
 import logger from "./utils/logger";
 
 async function main() {
@@ -26,6 +30,8 @@ async function main() {
   const deepResearchWorker = startDeepResearchWorker();
   const fileProcessWorker = createFileProcessWorker();
   const paperGenerationWorker = startPaperGenerationWorker();
+  const messageSweeperWorker = startMessageSweeperWorker();
+  await registerMessageSweeperSchedule();
 
   logger.info(
     {
@@ -35,7 +41,7 @@ async function main() {
       paperGenerationConcurrency: process.env.PAPER_GENERATION_CONCURRENCY || 1,
       redisUrl: process.env.REDIS_URL ? "[REDACTED]" : "redis://localhost:6379",
     },
-    "workers_started",
+    "workers_started"
   );
 
   // Graceful shutdown handler
@@ -49,6 +55,7 @@ async function main() {
       deepResearchWorker.close().then(() => logger.info("deep_research_worker_closed")),
       fileProcessWorker.close().then(() => logger.info("file_process_worker_closed")),
       paperGenerationWorker.close().then(() => logger.info("paper_generation_worker_closed")),
+      messageSweeperWorker.close().then(() => logger.info("message_sweeper_worker_closed")),
     ];
 
     logger.info("waiting_for_all_workers_to_finish_current_jobs");

--- a/supabase/migrations/20260428000000_add_message_status.sql
+++ b/supabase/migrations/20260428000000_add_message_status.sql
@@ -1,0 +1,34 @@
+-- Add status tracking to messages for crash recovery and orphan cleanup.
+-- Three states: PENDING (in flight), COMPLETE (durable reply saved), FAILED
+-- (terminal error or backend crashed before reply landed).
+
+ALTER TABLE public.messages
+ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'PENDING';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'messages_status_check'
+  ) THEN
+    ALTER TABLE public.messages
+    ADD CONSTRAINT messages_status_check
+    CHECK (status IN ('PENDING', 'COMPLETE', 'FAILED'));
+
+    -- Backfill runs exactly once, gated by the constraint-added branch above
+    -- so re-running this migration won't flip in-flight production rows.
+    UPDATE public.messages
+    SET status = CASE
+      WHEN content IS NOT NULL AND content <> '' THEN 'COMPLETE'
+      ELSE 'FAILED'
+    END
+    WHERE status = 'PENDING';
+  END IF;
+END $$;
+
+-- Partial index lets the periodic sweeper scan stuck-pending rows fast
+-- without bloating the index for the common COMPLETE case.
+CREATE INDEX IF NOT EXISTS idx_messages_status_pending
+ON public.messages (created_at)
+WHERE status = 'PENDING';


### PR DESCRIPTION
## Summary
Adds Server-Sent Events streaming to `POST /api/chat`. When the client
sends `Accept: text/event-stream`, the agent loop runs in-process and
streams tokens directly over the response. Non-SSE callers fall through
to the existing queue and JSON paths unchanged.

Supersedes #165 (that version routed streaming through Redis pub/sub in
queue mode, heavier than the 5-30s chat use case needs).

## Event contract
```
init          { messageId, conversationId }
stream_start  { turnIndex }
delta         { text, turnIndex }
stream_end    { isFinal, turnIndex, reason }   // paused | complete | truncated
done          { messageId }
error         { reason, message }              // reason e.g. truncated | empty_reply | agent_error
```

`turnIndex` is on every delta so the consumer can track turn boundaries
regardless of event ordering.

## Orphan recovery
A process death mid-stream would otherwise leave a `messages` row stuck
without a reply forever, breaking history loads and the UI loading
state. This PR adds chat-mode orphan recovery while preserving
deep-research's existing BullMQ retry model. The two boundary touches
in deep-research code (enqueue-time discriminator write, branch
normalization) exist to keep that scoping safe rather than to extend
the state machine into deep research.

- **Schema:** new `status` column on `messages` with values
  `PENDING / COMPLETE / FAILED`. Migration is idempotent; backfill runs
  only on first apply.
- **Chat writers:** SSE and non-SSE catch blocks call `markMessageFailed`
  on terminal errors (guarded with `.neq("status", "COMPLETE")` so a
  post-save throw can't downgrade a saved row).
- **Reader split:** new `getCompletedMessagesByConversation` is used
  only by the chat agent runner. The general `getMessagesByConversation`
  retains pre-PR behavior (returns all rows) for deep-research callers.
- **Sweeper:** periodic background job flips PENDING rows older than 20
  min to FAILED. Scoped to chat-mode rows by reading the related
  `state.values.isDeepResearch` flag — deep-research jobs (Steering
  ~20min, Smart ~60min, Autonomous up to ~8h) are excluded so legitimate
  runs aren't clobbered. Runs as a BullMQ repeatable job in queue mode
  and `setInterval` fallback in API server when `USE_JOB_QUEUE=false`.
- **Discriminator timing:** `isDeepResearch` is written to the state row
  at enqueue time in `start.ts` (strict — fails the request if the write
  fails) so queued deep-research jobs are excluded by the sweeper before
  their worker ever runs.

## Branch normalization
Branch copies now route every source row through a
`normalizeBranchedMessage` helper that rewrites PENDING source rows to
FAILED in the branched conversation. Rationale: the copy nullifies
`state_id`, so a PENDING row in the branch can never be picked up by a
worker — marking it FAILED keeps the branch internally consistent and
preserves the user's question. Unit tests cover all three status
transitions.

## Worth knowing
- `done` only emits after the reply is durably saved and post-save
  metadata updates complete, so a client seeing it can trust the
  message is fully written.
- Truncation is caught before the DB write. Partial `max_tokens` replies
  never persist as success.
- Client disconnect clears the heartbeat but lets the agent finish;
  refreshing mid-stream surfaces the full answer on reload.
- 15s SSE comment heartbeats cover long silent stretches (tool calls,
  file processing) so proxies don't kill idle connections.
- Sweeper's `state.values.isDeepResearch` lookup is a transitional
  discriminator. Long-term cleanup is a dedicated `kind` column on
  `messages` written atomically with the row insert; tracked as a
  follow-up.

## Migration
SQL file: `supabase/migrations/20260428000000_add_message_status.sql`.
Apply manually via Supabase SQL Editor. Already applied to staging.

## Validation
- TypeScript check clean (`bun typecheck`)
- 145 unit tests pass (`bun test`) — includes new
  `normalizeBranchedMessage` coverage
- Server boots cleanly with the migration applied

## Test plan
- [x] Curl smoke tests (simple query + tool-calling query)
- [x] Browser end-to-end (first message and follow-ups both stream)
- [x] Orphan recovery: kill backend mid-stream, verify row stays
      PENDING, sweeper flips to FAILED at threshold, chat-agent history
      loader excludes FAILED rows
- [x] Sweeper deep-research safety: queued deep-research job past
      threshold is NOT swept (isDeepResearch flag set at enqueue time)

Frontend PR: https://github.com/bio-xyz/bioagent-platform-ui/pull/112