### PR TITLE
Add credit topups processing migration

### DIFF
--- a/supabase/migrations/20260512000000_fix_credit_topups_processing_status.sql
+++ b/supabase/migrations/20260512000000_fix_credit_topups_processing_status.sql
@@ -1,6 +1,6 @@
 -- Add updated_at column
 ALTER TABLE public.credit_topups
-  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
 -- Update status constraint
 ALTER TABLE public.credit_topups

--- a/supabase/migrations/20260512000000_fix_credit_topups_processing_status.sql
+++ b/supabase/migrations/20260512000000_fix_credit_topups_processing_status.sql
@@ -1,0 +1,19 @@
+-- Add updated_at column
+ALTER TABLE public.credit_topups
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+
+-- Update status constraint
+ALTER TABLE public.credit_topups
+  DROP CONSTRAINT IF EXISTS credit_topups_status_check;
+
+ALTER TABLE public.credit_topups
+  ADD CONSTRAINT credit_topups_status_check
+  CHECK (status IN ('pending', 'processing', 'completed', 'failed', 'refunded'));
+
+-- Refresh update trigger
+DROP TRIGGER IF EXISTS update_credit_topups_updated_at ON public.credit_topups;
+
+CREATE TRIGGER update_credit_topups_updated_at
+  BEFORE UPDATE ON public.credit_topups
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();


### PR DESCRIPTION
## Summary

- Add a Supabase migration for `credit_topups` to support the Stripe top-up webhook claim flow.
- Add `updated_at` to `public.credit_topups`.
- Extend `credit_topups_status_check` to allow `processing`.
- Add an `updated_at` trigger using `public.update_updated_at_column()`.

## Testing

- `git diff --check`

## Notes

This migration should be applied before or alongside the UI webhook change that claims top-ups with `status = 'processing'` and updates `updated_at`.