### PR TITLE
fix: restore finalResponse write on deep-research completion

### DIFF
--- a/src/routes/deep-research/start.ts
+++ b/src/routes/deep-research/start.ts
@@ -1830,9 +1830,7 @@ These molecular changes align with established longevity pathways (Converging nu
 
       if (isFinal) {
         conversationState.values.finalResponse = replyResult.reply;
-        if (conversationState.id) {
-          await persistConversationState();
-        }
+        await persistConversationState();
       }
 
       // Notify client that message is ready

--- a/src/routes/deep-research/start.ts
+++ b/src/routes/deep-research/start.ts
@@ -1828,6 +1828,13 @@ These molecular changes align with established longevity pathways (Converging nu
         "iteration_reply_saved"
       );
 
+      if (isFinal) {
+        conversationState.values.finalResponse = replyResult.reply;
+        if (conversationState.id) {
+          await persistConversationState();
+        }
+      }
+
       // Notify client that message is ready
       await notifyMessageUpdated(
         `in-process-${currentMessage.id}`,

--- a/src/services/queue/workers/deep-research.worker.ts
+++ b/src/services/queue/workers/deep-research.worker.ts
@@ -1048,6 +1048,11 @@ async function processDeepResearchJob(
       "iteration_reply_saved"
     );
 
+    if (isFinal) {
+      conversationState.values.finalResponse = replyResult.reply;
+      await persistConversationState();
+    }
+
     // Notify message updated
     await notifyMessageUpdated(job.id!, conversationId, currentMessage.id);
 


### PR DESCRIPTION
## Summary

- The status endpoint (`status.ts:157`) and frontend (`DeepResearchMessageView.tsx`) both gate DR completion on `conversationState.values.finalResponse`, but nothing wrote that field after the reply agent finished
- The reply was saved to `messages.content` via `markMessageComplete`, but `finalResponse` in conversation state was never set
- Result: every DR run got stuck at "Drafting Response" forever on the UI, even though the reply was actually saved
- Reported by a user on prod who waited 4+ hours (PhD student, 2026-05-12)

**Fix:** Write `conversationState.values.finalResponse = replyResult.reply` when `isFinal` is true, in both execution paths:
- `src/routes/deep-research/start.ts` (in-process)
- `src/services/queue/workers/deep-research.worker.ts` (queue worker)

## Test plan

- Ran a full semi-autonomous DR query locally with the same query as the affected user
- DR completed end to end (2 iterations, 5 literature tasks)
- Verified in DB: `finalResponse` SET (5,635 chars), exact match with `messages.content`, `messages.status = COMPLETE`, `objectiveTrace.status = completed`
- Simulated status endpoint logic against DB state: returns `"completed"` (previously stuck on `"processing"`)
- `bun typecheck` passes clean