### PR TITLE
hotfix: restore finalResponse write on deep-research completion

### DIFF
--- a/src/routes/deep-research/start.ts
+++ b/src/routes/deep-research/start.ts
@@ -1830,9 +1830,7 @@ These molecular changes align with established longevity pathways (Converging nu
 
       if (isFinal) {
         conversationState.values.finalResponse = replyResult.reply;
-        if (conversationState.id) {
-          await persistConversationState();
-        }
+        await persistConversationState();
       }
 
       // Notify client that message is ready

--- a/src/routes/deep-research/start.ts
+++ b/src/routes/deep-research/start.ts
@@ -1828,6 +1828,13 @@ These molecular changes align with established longevity pathways (Converging nu
         "iteration_reply_saved"
       );
 
+      if (isFinal) {
+        conversationState.values.finalResponse = replyResult.reply;
+        if (conversationState.id) {
+          await persistConversationState();
+        }
+      }
+
       // Notify client that message is ready
       await notifyMessageUpdated(
         `in-process-${currentMessage.id}`,

--- a/src/services/queue/workers/deep-research.worker.ts
+++ b/src/services/queue/workers/deep-research.worker.ts
@@ -1048,6 +1048,11 @@ async function processDeepResearchJob(
       "iteration_reply_saved"
     );
 
+    if (isFinal) {
+      conversationState.values.finalResponse = replyResult.reply;
+      await persistConversationState();
+    }
+
     // Notify message updated
     await notifyMessageUpdated(job.id!, conversationId, currentMessage.id);
 


### PR DESCRIPTION
## Summary

Cherry-pick of PR #176 (already merged to dev) to fix a critical production bug.

`conversationState.values.finalResponse` was never written after the reply agent finished, causing every DR run to get stuck at "Drafting Response" forever. Both the status endpoint (`status.ts:157`) and the frontend depend on this field.

**Fix:** Write `finalResponse` to conversation state when `isFinal` in both execution paths.

**No schema changes. No migration needed.**

- `src/routes/deep-research/start.ts` (in-process)
- `src/services/queue/workers/deep-research.worker.ts` (queue worker)

## Test plan

- Tested locally end to end with same query as affected prod user
- DR completed, `finalResponse` written (5,635 chars), exact match with `messages.content`
- Already merged and verified on dev (PR #176, all CI passed, approved and reviewed)