### PR TITLE
fix: DR failure paths now flip message row to FAILED (BIOS-94)

### DIFF
--- a/src/routes/deep-research/__tests__/start.test.ts
+++ b/src/routes/deep-research/__tests__/start.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, mock, test } from "bun:test";
+import { __deepResearchStartTestables } from "../start";
+
+const { handleDeepResearchStartFailure } = __deepResearchStartTestables;
+
+const noop = async () => {};
+const noopSync = () => {};
+
+function makeMinimalDeps(
+  overrides: Partial<Parameters<typeof handleDeepResearchStartFailure>[1]> = {}
+) {
+  return {
+    clearDeepResearchActivity: noopSync,
+    ensureObjectiveTrace: noop,
+    getObjectiveTraceObjective: () => undefined,
+    logger: { error: () => {}, warn: () => {} },
+    markMessageFailed: noop,
+    markObjectiveTraceStale: noopSync,
+    markRunFinished: noop,
+    notifyStateUpdated: noop,
+    updateConversationState: noop,
+    updateState: noop,
+    ...overrides,
+  };
+}
+
+const baseParams = {
+  activeConversationState: null,
+  conversationId: "conv-1",
+  conversationStateId: "cs-1",
+  err: new Error("boom"),
+  notificationJobId: "in-process-msg-1",
+  rootMessageId: "msg-root",
+  stateRecord: { id: "state-1", values: {} as never },
+};
+
+describe("handleDeepResearchStartFailure", () => {
+  test("marks rootMessageId FAILED", async () => {
+    const markMessageFailed = mock(noop);
+    const deps = makeMinimalDeps({ markMessageFailed });
+
+    await handleDeepResearchStartFailure(baseParams, deps);
+
+    expect(markMessageFailed).toHaveBeenCalledWith("msg-root");
+  });
+
+  test("marks activeMessageId FAILED when it differs from rootMessageId", async () => {
+    const markMessageFailed = mock(noop);
+    const deps = makeMinimalDeps({ markMessageFailed });
+
+    await handleDeepResearchStartFailure(
+      { ...baseParams, activeMessageId: "msg-continuation" },
+      deps
+    );
+
+    expect(markMessageFailed).toHaveBeenCalledWith("msg-root");
+    expect(markMessageFailed).toHaveBeenCalledWith("msg-continuation");
+    expect(markMessageFailed).toHaveBeenCalledTimes(2);
+  });
+
+  test("does NOT mark activeMessageId when it equals rootMessageId", async () => {
+    const markMessageFailed = mock(noop);
+    const deps = makeMinimalDeps({ markMessageFailed });
+
+    await handleDeepResearchStartFailure({ ...baseParams, activeMessageId: "msg-root" }, deps);
+
+    expect(markMessageFailed).toHaveBeenCalledWith("msg-root");
+    expect(markMessageFailed).toHaveBeenCalledTimes(1);
+  });
+
+  test("still marks rootMessageId FAILED when updateState throws", async () => {
+    const markMessageFailed = mock(noop);
+    const deps = makeMinimalDeps({
+      markMessageFailed,
+      updateState: async () => {
+        throw new Error("DB down");
+      },
+    });
+
+    await handleDeepResearchStartFailure(baseParams, deps);
+
+    expect(markMessageFailed).toHaveBeenCalledWith("msg-root");
+  });
+
+  test("still marks continuation FAILED when rootMessageId mark throws", async () => {
+    const markMessageFailed = mock(async (id: string) => {
+      if (id === "msg-root") throw new Error("root mark failed");
+    });
+    const deps = makeMinimalDeps({ markMessageFailed });
+
+    await handleDeepResearchStartFailure(
+      { ...baseParams, activeMessageId: "msg-continuation" },
+      deps
+    );
+
+    // Both were attempted even though root threw
+    expect(markMessageFailed).toHaveBeenCalledWith("msg-root");
+    expect(markMessageFailed).toHaveBeenCalledWith("msg-continuation");
+  });
+});

--- a/src/routes/deep-research/__tests__/start.test.ts
+++ b/src/routes/deep-research/__tests__/start.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
-import { __deepResearchStartTestables } from "../start";
-
-const { handleDeepResearchStartFailure } = __deepResearchStartTestables;
+import { handleDeepResearchStartFailure } from "../failure-handler";
 
 const noop = async () => {};
 const noopSync = () => {};

--- a/src/routes/deep-research/failure-handler.ts
+++ b/src/routes/deep-research/failure-handler.ts
@@ -1,0 +1,144 @@
+import type { ConversationState, State } from "../../types/core";
+
+type DeepResearchStartFailureLogger = {
+  error: (payload: Record<string, unknown>, message: string) => void;
+  warn: (payload: Record<string, unknown>, message: string) => void;
+};
+
+export type DeepResearchStartFailureDeps = {
+  clearDeepResearchActivity: (values: ConversationState["values"]) => void;
+  ensureObjectiveTrace: (
+    values: ConversationState["values"],
+    objective?: string,
+    options?: { runRootMessageId?: string }
+  ) => Promise<unknown>;
+  getObjectiveTraceObjective: (
+    values: ConversationState["values"],
+    fallbackObjective?: string
+  ) => string | undefined;
+  markMessageFailed: (messageId: string) => Promise<void>;
+  markObjectiveTraceStale: (values: ConversationState["values"]) => unknown;
+  updateConversationState: (id: string, values: ConversationState["values"]) => Promise<unknown>;
+  notifyStateUpdated: (jobId: string, conversationId: string, stateId: string) => Promise<unknown>;
+  updateState: (id: string, values: Record<string, unknown>) => Promise<unknown>;
+  markRunFinished: (params: {
+    conversationStateId: string;
+    result: "failed";
+    error?: string;
+    rootMessageId?: string;
+    stateId?: string;
+  }) => Promise<unknown>;
+  logger: DeepResearchStartFailureLogger;
+};
+
+export type DeepResearchStartFailureParams = {
+  activeConversationState: ConversationState | null;
+  activeMessageId?: string;
+  conversationId: string;
+  conversationStateId: string;
+  err: unknown;
+  notificationJobId: string;
+  rootMessageId: string;
+  stateRecord: {
+    id: string;
+    values: State["values"];
+  };
+};
+
+export async function handleDeepResearchStartFailure(
+  params: DeepResearchStartFailureParams,
+  deps: DeepResearchStartFailureDeps
+): Promise<void> {
+  const {
+    activeConversationState,
+    activeMessageId,
+    conversationId,
+    conversationStateId,
+    err,
+    notificationJobId,
+    rootMessageId,
+    stateRecord,
+  } = params;
+
+  const errorMessage = err instanceof Error ? err.message : "Unknown error";
+
+  if (activeConversationState?.id) {
+    try {
+      deps.clearDeepResearchActivity(activeConversationState.values);
+      await deps.ensureObjectiveTrace(
+        activeConversationState.values,
+        deps.getObjectiveTraceObjective(activeConversationState.values),
+        {
+          runRootMessageId: rootMessageId,
+        }
+      );
+      deps.markObjectiveTraceStale(activeConversationState.values);
+      await deps.updateConversationState(
+        activeConversationState.id,
+        activeConversationState.values
+      );
+      await deps.notifyStateUpdated(notificationJobId, conversationId, activeConversationState.id);
+    } catch (cleanupErr) {
+      deps.logger.error(
+        {
+          cleanupErr,
+          conversationStateId,
+          messageId: notificationJobId,
+          originalErr: err,
+          rootMessageId,
+        },
+        "deep_research_error_cleanup_failed"
+      );
+    }
+  }
+
+  try {
+    await deps.updateState(stateRecord.id, {
+      ...stateRecord.values,
+      error: errorMessage,
+      status: "failed",
+    });
+  } catch (updateErr) {
+    deps.logger.error({ updateErr }, "deep_research_update_state_on_failure_failed");
+  }
+
+  try {
+    await deps.markMessageFailed(rootMessageId);
+  } catch (msgErr) {
+    deps.logger.warn({ msgErr, rootMessageId }, "deep_research_mark_message_failed_on_failure");
+  }
+
+  // If auto-continuation created a new message row before the failure, mark
+  // that row FAILED too. markMessageFailed guards .neq("status", "COMPLETE")
+  // so calling it on an already-completed root is safe.
+  if (activeMessageId && activeMessageId !== rootMessageId) {
+    try {
+      await deps.markMessageFailed(activeMessageId);
+    } catch (msgErr) {
+      deps.logger.warn(
+        { activeMessageId, msgErr },
+        "deep_research_mark_continuation_message_failed_on_failure"
+      );
+    }
+  }
+
+  try {
+    await deps.markRunFinished({
+      conversationStateId,
+      error: errorMessage,
+      result: "failed",
+      rootMessageId,
+      stateId: stateRecord.id,
+    });
+  } catch (finishError) {
+    deps.logger.warn(
+      {
+        conversationStateId,
+        finishError,
+        rootMessageId,
+        stateId: stateRecord.id,
+      },
+      "deep_research_run_finish_mark_failed_on_failure"
+    );
+  }
+}

--- a/src/routes/deep-research/start.ts
+++ b/src/routes/deep-research/start.ts
@@ -200,11 +200,15 @@ async function handleDeepResearchStartFailure(
     }
   }
 
-  await deps.updateState(stateRecord.id, {
-    ...stateRecord.values,
-    error: errorMessage,
-    status: "failed",
-  });
+  try {
+    await deps.updateState(stateRecord.id, {
+      ...stateRecord.values,
+      error: errorMessage,
+      status: "failed",
+    });
+  } catch (updateErr) {
+    deps.logger.error({ updateErr }, "deep_research_update_state_on_failure_failed");
+  }
 
   try {
     await markMessageFailed(rootMessageId);

--- a/src/routes/deep-research/start.ts
+++ b/src/routes/deep-research/start.ts
@@ -115,6 +115,7 @@ type DeepResearchStartFailureDeps = {
     values: ConversationState["values"],
     fallbackObjective?: string
   ) => string | undefined;
+  markMessageFailed: (messageId: string) => Promise<void>;
   markObjectiveTraceStale: (values: ConversationState["values"]) => unknown;
   updateConversationState: (id: string, values: ConversationState["values"]) => Promise<unknown>;
   notifyStateUpdated: (jobId: string, conversationId: string, stateId: string) => Promise<unknown>;
@@ -131,6 +132,7 @@ type DeepResearchStartFailureDeps = {
 
 type DeepResearchStartFailureParams = {
   activeConversationState: ConversationState | null;
+  activeMessageId?: string;
   conversationId: string;
   conversationStateId: string;
   err: unknown;
@@ -147,6 +149,7 @@ const deepResearchStartFailureDeps: DeepResearchStartFailureDeps = {
   ensureObjectiveTrace,
   getObjectiveTraceObjective,
   logger,
+  markMessageFailed,
   markObjectiveTraceStale,
   markRunFinished,
   notifyStateUpdated,
@@ -160,6 +163,7 @@ async function handleDeepResearchStartFailure(
 ): Promise<void> {
   const {
     activeConversationState,
+    activeMessageId,
     conversationId,
     conversationStateId,
     err,
@@ -211,9 +215,23 @@ async function handleDeepResearchStartFailure(
   }
 
   try {
-    await markMessageFailed(rootMessageId);
+    await deps.markMessageFailed(rootMessageId);
   } catch (msgErr) {
     deps.logger.warn({ msgErr, rootMessageId }, "deep_research_mark_message_failed_on_failure");
+  }
+
+  // If auto-continuation created a new message row before the failure, mark
+  // that row FAILED too. markMessageFailed guards .neq("status", "COMPLETE")
+  // so calling it on an already-completed root is safe.
+  if (activeMessageId && activeMessageId !== rootMessageId) {
+    try {
+      await deps.markMessageFailed(activeMessageId);
+    } catch (msgErr) {
+      deps.logger.warn(
+        { activeMessageId, msgErr },
+        "deep_research_mark_continuation_message_failed_on_failure"
+      );
+    }
   }
 
   try {
@@ -386,6 +404,7 @@ export async function deepResearchStartHandler(ctx: ElysiaRouteContext) {
   let createdMessage: CreatedMessage | null = null;
   let runMarkedStarted = false;
   let activeConversationState: ConversationState | null = null;
+  let queueJobEnqueued = false;
 
   // Log with state IDs now that we have them
   logger.info(
@@ -707,6 +726,7 @@ export async function deepResearchStartHandler(ctx: ElysiaRouteContext) {
           jobId: createdMessage.id, // Use message ID as job ID for easy lookup
         }
       );
+      queueJobEnqueued = true;
 
       activeConversationState = {
         id: conversationStateRecord.id,
@@ -722,9 +742,19 @@ export async function deepResearchStartHandler(ctx: ElysiaRouteContext) {
           message,
         phase: "planning",
       });
-      // Keep queue mode fast: the worker generates the initial objective trace.
-      await updateConversationState(activeConversationState.id!, activeConversationState.values);
-      await notifyStateUpdated(job.id!, conversationId, activeConversationState.id!);
+      // Post-enqueue UI writes are best-effort. The BullMQ job is already live so
+      // any failure here must not reach the outer catch: that catch still calls
+      // updateState({status:"failed"}) and markRunFinished, which would poison the
+      // status endpoint and flip isRunning=false while the worker is still running.
+      try {
+        await updateConversationState(activeConversationState.id!, activeConversationState.values);
+        await notifyStateUpdated(job.id!, conversationId, activeConversationState.id!);
+      } catch (postEnqueueErr) {
+        logger.warn(
+          { conversationId, jobId: job.id, postEnqueueErr },
+          "deep_research_post_enqueue_state_update_failed"
+        );
+      }
 
       try {
         await updateRunJobId({
@@ -789,13 +819,21 @@ export async function deepResearchStartHandler(ctx: ElysiaRouteContext) {
           "deep_research_state_mark_failed_on_queue_error"
         );
       }
-      try {
-        await markMessageFailed(createdMessage.id);
-      } catch (msgErr) {
-        logger.warn(
-          { messageId: createdMessage.id, msgErr },
-          "deep_research_mark_message_failed_on_queue_error"
-        );
+      // Only mark message FAILED if the BullMQ job was never created.
+      // Once queue.add succeeds the job is live; the worker owns the
+      // message row from that point and will call markMessageComplete or
+      // markMessageFailed itself. Marking FAILED here would race with the
+      // worker's markMessageComplete(.eq("status", "PENDING")) and
+      // permanently orphan the reply.
+      if (!queueJobEnqueued) {
+        try {
+          await markMessageFailed(createdMessage.id);
+        } catch (msgErr) {
+          logger.warn(
+            { messageId: createdMessage.id, msgErr },
+            "deep_research_mark_message_failed_on_queue_error"
+          );
+        }
       }
       if (runMarkedStarted) {
         try {
@@ -925,6 +963,7 @@ async function runDeepResearch(params: {
     conversationStateId,
   } = params;
   let activeConversationState: ConversationState | null = null;
+  let currentMessage: CreatedMessage = createdMessage;
   let readCancellationRequested: () => Promise<boolean> = async () => false;
 
   try {
@@ -1004,7 +1043,9 @@ async function runDeepResearch(params: {
     };
 
     // Track the current message being updated (changes when auto-continuing)
-    let currentMessage = createdMessage;
+    // Note: currentMessage is declared in the outer scope so the catch block
+    // can pass activeMessageId to handleDeepResearchStartFailure.
+    currentMessage = createdMessage;
     type ConversationStateWriteOptions = {
       ensureTraceObjective?: string;
       completeTrace?: boolean;
@@ -2100,6 +2141,7 @@ These molecular changes align with established longevity pathways (Converging nu
 
     await handleDeepResearchStartFailure({
       activeConversationState,
+      activeMessageId: currentMessage.id,
       conversationId: createdMessage.conversation_id,
       conversationStateId,
       err,

--- a/src/routes/deep-research/start.ts
+++ b/src/routes/deep-research/start.ts
@@ -23,7 +23,7 @@ import {
 import { authResolver } from "../../middleware/authResolver";
 import { rateLimitMiddleware } from "../../middleware/rateLimiter";
 import { ensureUserAndConversation, setupConversationData } from "../../services/chat/setup";
-import { createMessageRecord } from "../../services/chat/tools";
+import { createMessageRecord, markMessageFailed } from "../../services/chat/tools";
 import {
   DeepResearchCancelledError,
   isDeepResearchCancellationRequested,
@@ -207,7 +207,6 @@ async function handleDeepResearchStartFailure(
   });
 
   try {
-    const { markMessageFailed } = await import("../../services/chat/tools");
     await markMessageFailed(rootMessageId);
   } catch (msgErr) {
     deps.logger.warn({ msgErr, rootMessageId }, "deep_research_mark_message_failed_on_failure");
@@ -787,7 +786,6 @@ export async function deepResearchStartHandler(ctx: ElysiaRouteContext) {
         );
       }
       try {
-        const { markMessageFailed } = await import("../../services/chat/tools");
         await markMessageFailed(createdMessage.id);
       } catch (msgErr) {
         logger.warn(
@@ -863,7 +861,6 @@ export async function deepResearchStartHandler(ctx: ElysiaRouteContext) {
       );
     }
     try {
-      const { markMessageFailed } = await import("../../services/chat/tools");
       await markMessageFailed(createdMessage.id);
     } catch (msgErr) {
       logger.warn(

--- a/src/routes/deep-research/start.ts
+++ b/src/routes/deep-research/start.ts
@@ -99,50 +99,10 @@ type DeepResearchQueuedResponse = {
   deduplicated?: true;
 };
 
-type DeepResearchStartFailureLogger = {
-  error: (payload: Record<string, unknown>, message: string) => void;
-  warn: (payload: Record<string, unknown>, message: string) => void;
-};
-
-type DeepResearchStartFailureDeps = {
-  clearDeepResearchActivity: (values: ConversationState["values"]) => void;
-  ensureObjectiveTrace: (
-    values: ConversationState["values"],
-    objective?: string,
-    options?: { runRootMessageId?: string }
-  ) => Promise<unknown>;
-  getObjectiveTraceObjective: (
-    values: ConversationState["values"],
-    fallbackObjective?: string
-  ) => string | undefined;
-  markMessageFailed: (messageId: string) => Promise<void>;
-  markObjectiveTraceStale: (values: ConversationState["values"]) => unknown;
-  updateConversationState: (id: string, values: ConversationState["values"]) => Promise<unknown>;
-  notifyStateUpdated: (jobId: string, conversationId: string, stateId: string) => Promise<unknown>;
-  updateState: (id: string, values: Record<string, unknown>) => Promise<unknown>;
-  markRunFinished: (params: {
-    conversationStateId: string;
-    result: "failed";
-    error?: string;
-    rootMessageId?: string;
-    stateId?: string;
-  }) => Promise<unknown>;
-  logger: DeepResearchStartFailureLogger;
-};
-
-type DeepResearchStartFailureParams = {
-  activeConversationState: ConversationState | null;
-  activeMessageId?: string;
-  conversationId: string;
-  conversationStateId: string;
-  err: unknown;
-  notificationJobId: string;
-  rootMessageId: string;
-  stateRecord: {
-    id: string;
-    values: State["values"];
-  };
-};
+import {
+  type DeepResearchStartFailureDeps,
+  handleDeepResearchStartFailure,
+} from "./failure-handler";
 
 const deepResearchStartFailureDeps: DeepResearchStartFailureDeps = {
   clearDeepResearchActivity,
@@ -156,104 +116,6 @@ const deepResearchStartFailureDeps: DeepResearchStartFailureDeps = {
   updateConversationState,
   updateState,
 };
-
-async function handleDeepResearchStartFailure(
-  params: DeepResearchStartFailureParams,
-  deps: DeepResearchStartFailureDeps = deepResearchStartFailureDeps
-): Promise<void> {
-  const {
-    activeConversationState,
-    activeMessageId,
-    conversationId,
-    conversationStateId,
-    err,
-    notificationJobId,
-    rootMessageId,
-    stateRecord,
-  } = params;
-
-  const errorMessage = err instanceof Error ? err.message : "Unknown error";
-
-  if (activeConversationState?.id) {
-    try {
-      deps.clearDeepResearchActivity(activeConversationState.values);
-      await deps.ensureObjectiveTrace(
-        activeConversationState.values,
-        deps.getObjectiveTraceObjective(activeConversationState.values),
-        {
-          runRootMessageId: rootMessageId,
-        }
-      );
-      deps.markObjectiveTraceStale(activeConversationState.values);
-      await deps.updateConversationState(
-        activeConversationState.id,
-        activeConversationState.values
-      );
-      await deps.notifyStateUpdated(notificationJobId, conversationId, activeConversationState.id);
-    } catch (cleanupErr) {
-      deps.logger.error(
-        {
-          cleanupErr,
-          conversationStateId,
-          messageId: notificationJobId,
-          originalErr: err,
-          rootMessageId,
-        },
-        "deep_research_error_cleanup_failed"
-      );
-    }
-  }
-
-  try {
-    await deps.updateState(stateRecord.id, {
-      ...stateRecord.values,
-      error: errorMessage,
-      status: "failed",
-    });
-  } catch (updateErr) {
-    deps.logger.error({ updateErr }, "deep_research_update_state_on_failure_failed");
-  }
-
-  try {
-    await deps.markMessageFailed(rootMessageId);
-  } catch (msgErr) {
-    deps.logger.warn({ msgErr, rootMessageId }, "deep_research_mark_message_failed_on_failure");
-  }
-
-  // If auto-continuation created a new message row before the failure, mark
-  // that row FAILED too. markMessageFailed guards .neq("status", "COMPLETE")
-  // so calling it on an already-completed root is safe.
-  if (activeMessageId && activeMessageId !== rootMessageId) {
-    try {
-      await deps.markMessageFailed(activeMessageId);
-    } catch (msgErr) {
-      deps.logger.warn(
-        { activeMessageId, msgErr },
-        "deep_research_mark_continuation_message_failed_on_failure"
-      );
-    }
-  }
-
-  try {
-    await deps.markRunFinished({
-      conversationStateId,
-      error: errorMessage,
-      result: "failed",
-      rootMessageId,
-      stateId: stateRecord.id,
-    });
-  } catch (finishError) {
-    deps.logger.warn(
-      {
-        conversationStateId,
-        finishError,
-        rootMessageId,
-        stateId: stateRecord.id,
-      },
-      "deep_research_run_finish_mark_failed_on_failure"
-    );
-  }
-}
 
 export const __deepResearchStartTestables = {
   handleDeepResearchStartFailure,
@@ -2139,15 +2001,18 @@ These molecular changes align with established longevity pathways (Converging nu
 
     logger.error({ err, messageId: createdMessage.id }, "deep_research_execution_failed");
 
-    await handleDeepResearchStartFailure({
-      activeConversationState,
-      activeMessageId: currentMessage.id,
-      conversationId: createdMessage.conversation_id,
-      conversationStateId,
-      err,
-      notificationJobId: `in-process-${createdMessage.id || stateRecord.id}`,
-      rootMessageId,
-      stateRecord,
-    });
+    await handleDeepResearchStartFailure(
+      {
+        activeConversationState,
+        activeMessageId: currentMessage.id,
+        conversationId: createdMessage.conversation_id,
+        conversationStateId,
+        err,
+        notificationJobId: `in-process-${createdMessage.id || stateRecord.id}`,
+        rootMessageId,
+        stateRecord,
+      },
+      deepResearchStartFailureDeps
+    );
   }
 }

--- a/src/routes/deep-research/start.ts
+++ b/src/routes/deep-research/start.ts
@@ -207,6 +207,13 @@ async function handleDeepResearchStartFailure(
   });
 
   try {
+    const { markMessageFailed } = await import("../../services/chat/tools");
+    await markMessageFailed(rootMessageId);
+  } catch (msgErr) {
+    deps.logger.warn({ msgErr, rootMessageId }, "deep_research_mark_message_failed_on_failure");
+  }
+
+  try {
     await deps.markRunFinished({
       conversationStateId,
       error: errorMessage,
@@ -779,6 +786,15 @@ export async function deepResearchStartHandler(ctx: ElysiaRouteContext) {
           "deep_research_state_mark_failed_on_queue_error"
         );
       }
+      try {
+        const { markMessageFailed } = await import("../../services/chat/tools");
+        await markMessageFailed(createdMessage.id);
+      } catch (msgErr) {
+        logger.warn(
+          { messageId: createdMessage.id, msgErr },
+          "deep_research_mark_message_failed_on_queue_error"
+        );
+      }
       if (runMarkedStarted) {
         try {
           await markRunFinished({
@@ -844,6 +860,15 @@ export async function deepResearchStartHandler(ctx: ElysiaRouteContext) {
       logger.warn(
         { error: stateErr, stateId: stateRecord.id },
         "deep_research_state_mark_failed_on_in_process_start_error"
+      );
+    }
+    try {
+      const { markMessageFailed } = await import("../../services/chat/tools");
+      await markMessageFailed(createdMessage.id);
+    } catch (msgErr) {
+      logger.warn(
+        { messageId: createdMessage.id, msgErr },
+        "deep_research_mark_message_failed_on_in_process_start_error"
       );
     }
     if (runMarkedStarted) {

--- a/src/services/queue/workers/deep-research.worker.ts
+++ b/src/services/queue/workers/deep-research.worker.ts
@@ -1206,27 +1206,42 @@ async function processDeepResearchJob(
       const nextMessageId = agentMessage.id!; // createMessage always returns an ID
       const nextJobName = `iteration-${iterationNumber + 1}-${nextMessageId}`;
 
-      await queue.add(
-        nextJobName,
-        {
-          authMethod: job.data.authMethod,
-          conversationId,
-          conversationStateId,
-          isInitialIteration: false, // Use promoted tasks, skip planning
-          iterationNumber: iterationNumber + 1,
-          message, // Original message for context
-          messageId: nextMessageId, // Next iteration writes to new message
-          requestedAt: new Date().toISOString(),
-          researchMode,
-          rootJobId: rootJobId || job.id!, // Track the chain back to original
-          rootMessageId,
-          stateId,
-          userId,
-        },
-        {
-          jobId: nextMessageId, // Use message ID as job ID for easy lookup
+      try {
+        await queue.add(
+          nextJobName,
+          {
+            authMethod: job.data.authMethod,
+            conversationId,
+            conversationStateId,
+            isInitialIteration: false, // Use promoted tasks, skip planning
+            iterationNumber: iterationNumber + 1,
+            message, // Original message for context
+            messageId: nextMessageId, // Next iteration writes to new message
+            requestedAt: new Date().toISOString(),
+            researchMode,
+            rootJobId: rootJobId || job.id!, // Track the chain back to original
+            rootMessageId,
+            stateId,
+            userId,
+          },
+          {
+            jobId: nextMessageId, // Use message ID as job ID for easy lookup
+          }
+        );
+      } catch (enqueueErr) {
+        // The continuation message row exists in DB but no BullMQ job owns it.
+        // Mark it FAILED immediately so the status endpoint and UI won't spin forever.
+        try {
+          const { markMessageFailed } = await import("../../chat/tools");
+          await markMessageFailed(nextMessageId);
+        } catch (msgErr) {
+          logger.warn(
+            { msgErr, nextMessageId },
+            "deep_research_worker_mark_continuation_message_failed_on_enqueue_error"
+          );
         }
-      );
+        throw enqueueErr;
+      }
 
       logger.info(
         {
@@ -1390,10 +1405,17 @@ async function processDeepResearchJob(
         logger.warn({ messageId, msgErr }, "deep_research_worker_mark_message_failed_on_failure");
       }
 
-      await clearConversationActivity({ staleTrace: true });
+      try {
+        await clearConversationActivity({ staleTrace: true });
+      } catch (activityErr) {
+        logger.warn({ activityErr }, "deep_research_worker_clear_activity_failed_on_error");
+      }
 
-      // Notify: Job failed
-      await notifyJobFailed(job.id!, conversationId, messageId, stateId);
+      try {
+        await notifyJobFailed(job.id!, conversationId, messageId, stateId);
+      } catch (notifyErr) {
+        logger.warn({ notifyErr }, "deep_research_worker_notify_job_failed_error");
+      }
 
       try {
         await markRunFinished({

--- a/src/services/queue/workers/deep-research.worker.ts
+++ b/src/services/queue/workers/deep-research.worker.ts
@@ -1379,40 +1379,44 @@ async function processDeepResearchJob(
           error: error instanceof Error ? error.message : "Unknown error",
           status: "failed",
         });
+      } catch (updateErr) {
+        logger.error({ updateErr }, "failed_to_update_state_on_error");
+      }
 
-        try {
-          const { markMessageFailed } = await import("../../../services/chat/tools");
-          await markMessageFailed(messageId);
-        } catch (msgErr) {
-          logger.warn({ messageId, msgErr }, "deep_research_worker_mark_message_failed_on_failure");
-        }
+      try {
+        const { markMessageFailed } = await import("../../../services/chat/tools");
+        await markMessageFailed(messageId);
+      } catch (msgErr) {
+        logger.warn({ messageId, msgErr }, "deep_research_worker_mark_message_failed_on_failure");
+      }
 
-        await clearConversationActivity({ staleTrace: true });
+      await clearConversationActivity({ staleTrace: true });
 
-        // Notify: Job failed
-        await notifyJobFailed(job.id!, conversationId, messageId, stateId);
+      // Notify: Job failed
+      await notifyJobFailed(job.id!, conversationId, messageId, stateId);
 
-        try {
-          await markRunFinished({
+      try {
+        await markRunFinished({
+          conversationStateId,
+          error: error instanceof Error ? error.message : "Unknown error",
+          result: "failed",
+          rootMessageId,
+          stateId,
+        });
+      } catch (finishError) {
+        logger.warn(
+          {
             conversationStateId,
-            error: error instanceof Error ? error.message : "Unknown error",
-            result: "failed",
+            finishError,
             rootMessageId,
             stateId,
-          });
-        } catch (finishError) {
-          logger.warn(
-            {
-              conversationStateId,
-              finishError,
-              rootMessageId,
-              stateId,
-            },
-            "deep_research_worker_finish_mark_failed_on_failure"
-          );
-        }
+          },
+          "deep_research_worker_finish_mark_failed_on_failure"
+        );
+      }
 
-        // Refund credits on final failure
+      // Refund credits on final failure
+      try {
         const { getServiceClient } = await import("../../../db/client");
         const supabase = getServiceClient();
 
@@ -1438,8 +1442,8 @@ async function processDeepResearchJob(
             logger.info({ privyId, refunded: data?.refunded }, "credits_refunded_on_failure");
           }
         }
-      } catch (updateErr) {
-        logger.error({ updateErr }, "failed_to_update_state_on_error");
+      } catch (creditErr) {
+        logger.error({ creditErr }, "failed_to_refund_credits_on_error");
       }
     }
 

--- a/src/services/queue/workers/deep-research.worker.ts
+++ b/src/services/queue/workers/deep-research.worker.ts
@@ -1399,7 +1399,7 @@ async function processDeepResearchJob(
       }
 
       try {
-        const { markMessageFailed } = await import("../../../services/chat/tools");
+        const { markMessageFailed } = await import("../../chat/tools");
         await markMessageFailed(messageId);
       } catch (msgErr) {
         logger.warn({ messageId, msgErr }, "deep_research_worker_mark_message_failed_on_failure");

--- a/src/services/queue/workers/deep-research.worker.ts
+++ b/src/services/queue/workers/deep-research.worker.ts
@@ -1380,6 +1380,13 @@ async function processDeepResearchJob(
           status: "failed",
         });
 
+        try {
+          const { markMessageFailed } = await import("../../../services/chat/tools");
+          await markMessageFailed(messageId);
+        } catch (msgErr) {
+          logger.warn({ messageId, msgErr }, "deep_research_worker_mark_message_failed_on_failure");
+        }
+
         await clearConversationActivity({ staleTrace: true });
 
         // Notify: Job failed


### PR DESCRIPTION
Closes BIOS-94.

## Summary

Deep-research failure paths were marking only the state row as `failed`; they were not calling `markMessageFailed` for the corresponding `messages` row. Because the orphan-recovery sweeper intentionally excludes deep-research rows, a crashed or failed DR run could leave a message permanently stuck in `PENDING`. Frontend consumers would then see the run as still pending indefinitely.

This PR adds `markMessageFailed(messageId)` to all four deep-research failure paths:

- `handleDeepResearchStartFailure` in `start.ts` — covers in-process runtime failures
- Queue-mode enqueue error in `start.ts` — covers failures before the worker picks up the job
- In-process start error in `start.ts` — covers early startup failures before the background run is fully underway
- Worker error handler in `deep-research.worker.ts` — covers worker-side failures on the final attempt

Each call is wrapped in its own `try/catch`, so a failure updating the `messages` table does not block the surrounding error cleanup. The existing `markMessageFailed` guard (`.neq("status", "COMPLETE")`) still prevents downgrading a row that has already completed. `normalizeBranchedMessage` remains a defensive layer for branched conversations.

## Test plan

- Trigger a deep-research failure (for example, kill the worker mid-run or force an error) and verify that the `messages` row flips to `FAILED` instead of staying `PENDING`
- Verify that a successful deep-research run is unaffected